### PR TITLE
Add timestamper plugin

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -17,6 +17,7 @@
       - blueocean-autofavorite
       - blueocean-personalization
       - azure-credentials
+      - timestamper
 #      - blueocean-jwt
 #      - blueocean-rest-impl
 #      - favorite


### PR DESCRIPTION
https://plugins.jenkins.io/timestamper
Allows timestamps to be added to the log to show how long operations are taking and if jenkins is actually doing something, very useful and would love to get it in

Is this the right place, to add plugins?