### PR TITLE
Add timestamper plugin

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -32,6 +32,7 @@
       - greenballs
       - custom-tools-plugin
       - http-request
+      - timestamper
 
 #      - favorite
 #      - credentials


### PR DESCRIPTION
https://plugins.jenkins.io/timestamper
Allows timestamps to be added to the log to show how long operations are taking and if jenkins is actually doing something, very useful and would love to get it in