### PR TITLE
Removing nodejs plugin

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -39,7 +39,6 @@
       - slack
       - timestamper
       - sonar
-      - nodejs
       - workflow-aggregator
 #      - favorite
 #      - credentials


### PR DESCRIPTION
Nodejs is now installed system wide (see the jenkins deps role)