### PR TITLE
Added Build monitor plugin

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -40,6 +40,7 @@
       - timestamper
       - sonar
       - workflow-aggregator
+      - build-monitor-plugin
 
     jenkins_manual_plugins:
       - file_name: 'azure-keyvault.hpi'


### PR DESCRIPTION
In order to have visibility about the builds.  I know we can do this with blue ocean dashboard favourites but its bit cluttered with more information

Notes:
* Adding build monitor plugin will give good visibility about the builds.
* I know we can do this by blue ocean dashboard favourites, but its not as clear as build monitor

