### PR TITLE
Don't include global libraries in change logs

### DIFF
--- a/roles/jenkins/templates/global-pipeline-library.groovy
+++ b/roles/jenkins/templates/global-pipeline-library.groovy
@@ -20,6 +20,7 @@ LibraryConfiguration libToAdd =
 libToAdd.setDefaultVersion("{{ global_lib.default_version }}")
 libToAdd.setImplicit(true)
 libToAdd.setAllowVersionOverride(true);
+libToAdd.setIncludeInChangesets(false);
 
 def preConfiguredLibs = globalLibsConfigurator.get().getLibraries()
 if (preConfiguredLibs != null) {


### PR DESCRIPTION
Should stop lots of builds starting

