### PR TITLE
[NEEDS TESTING] Use github api token instead of SSH for checkout

### DIFF
--- a/roles/jenkins/templates/github-folder-multi-branch.xml.j2
+++ b/roles/jenkins/templates/github-folder-multi-branch.xml.j2
@@ -103,9 +103,6 @@
           <includes>{{ folder.branchesToinclude | default('master') }} cnp PR*</includes>
           <excludes/>
         </jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait>
-        <org.jenkinsci.plugins.github__branch__source.SSHCheckoutTrait>
-          <credentialsId>git_access_ssh_key</credentialsId>
-        </org.jenkinsci.plugins.github__branch__source.SSHCheckoutTrait>
       </traits>
     </org.jenkinsci.plugins.github__branch__source.GitHubSCMNavigator>
   </navigators>


### PR DESCRIPTION
That way checkout of the Jenkinsfile, org scanning and full checkout all
use the same api token.