### PR TITLE
ROC-3253 Allow viewing test reports, fix timezone

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -136,6 +136,10 @@
     jenkins_agent_executors: "4"
     jenkins_agent_private_ip: true
 
+    jenkins_timezone: '-Dorg.apache.commons.jelly.tags.fmt.timeZone=Europe/London'
+    jenkins_csp_policy: '-Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src ''self''; script-src ''self'' ''unsafe-inline''; style-src ''self'' ''unsafe-inline''; font-src data:\"'
+    jenkins_java_options: "-Djenkins.install.runSetupWizard=false {{ jenkins_csp_policy }} {{ jenkins_timezone }}'"
+
   roles:
     - role: ansible-terraform
     - role: azure-cli


### PR DESCRIPTION
* Set CSP policy to match the tactical one, this allows viewing the mocha awesome test reports, / some other reports that teams use.
* Set timezone to London to fix DST offset
https://tools.hmcts.net/jira/browse/ROC-3253