### PR TITLE
Honour lib configuration set in playbook

### DIFF
--- a/roles/jenkins/templates/global-pipeline-library.groovy
+++ b/roles/jenkins/templates/global-pipeline-library.groovy
@@ -16,10 +16,10 @@ LibraryConfiguration libToAdd =
                 credentialsId = "git_access_key",
                 includes = "*",
                 excludes = "",
-                ignoreOnPushNotifications = {{ global_lib.ignore_on_push_notifications }})))
+                ignoreOnPushNotifications = Boolean.valueOf("{{ global_lib.ignore_on_push_notifications }}"))))
 libToAdd.setDefaultVersion("{{ global_lib.default_version }}")
-libToAdd.setImplicit({{ global_lib.set_implicit }})
-libToAdd.setAllowVersionOverride({{ global_lib.allow_version_override }});
+libToAdd.setImplicit(Boolean.valueOf("{{ global_lib.set_implicit }}"))
+libToAdd.setAllowVersionOverride(Boolean.valueOf("{{ global_lib.allow_version_override }}"));
 libToAdd.setIncludeInChangesets(false);
 
 def preConfiguredLibs = globalLibsConfigurator.get().getLibraries()


### PR DESCRIPTION
Resolves CNP-504

Set 'load implicitly' to false for 'Infrastructure' global library. It was already set to 'false' in the playbook but the config wasn't applied all the way through so just fixed that.

Tested locally with vagrant.