### PR TITLE
Perform nightly builds on magic CDM nightly branches

### DIFF
--- a/env_vars/prod.yml
+++ b/env_vars/prod.yml
@@ -72,7 +72,7 @@ organization_folders:
     credentials_id: 'jenkins-github-hmcts-api-token_cmc'
     github_api_url: 'https://api.github.com'
     jenkinsfile_path: ['Jenkinsfile_nightly']
-    branches_to_include: 'master'
+    branches_to_include: 'master nightly*'
     regex_SCM_source_filter: '\b(?:document-management-store-app|dm-shared-infrastructure|ccd.*)\b'
   - name: 'HMCTS_IAC'
     repo_owner: 'HMCTS'


### PR DESCRIPTION
Any CDM branch starting with nightly can be auto built on the nightly
pipeline.  Allows us to test things that aren't quite ready for the full
nightly pipeline.

RDM-3264