### PR TITLE
Fix CDM build monitior regexes

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -31,13 +31,13 @@ jenkins:
         title: RPA-PR
     - buildMonitor:
         includeRegex: >-
-          .+HMCTS_CDM.+\/master
+          HMCTS_CDM.+\/master
         name: CDM
         recurse: true
         title: CDM master Builds
     - buildMonitor:
         includeRegex: >-
-          .+HMCTS_Nightly_CDM.+\/master
+          HMCTS_Nightly_CDM.+\/master
         name: CDM Nightly
         recurse: true
         title: CDM Nightly Builds


### PR DESCRIPTION
They follow: HMCTS_$team/$repo/$branch so adjust regex accordingly