### PR TITLE
Added SSCS and IA dashboards to cac-prod.yml

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -41,3 +41,15 @@ jenkins:
         name: CDM Nightly
         recurse: true
         title: CDM Nightly Builds
+    - buildMonitor:
+        includeRegex: >-
+          ^HMCTS_.*SSCS.*\/(sscs-bulk-scan|sscs-case-loader|sscs-cor-backend|sscs-cor-frontend|sscs-shared-infrastructure|sscs-submit-your-appeal|sscs-track-your-appeal-frontend|sscs-track-your-appeal-notifications|sscs-tribunals-case-api|sscs-ccd-e2e-tests)\/master
+        name: SSCS
+        recurse: true
+        title: SSCS Dashboard
+    - buildMonitor:
+        includeRegex: >-
+          ^HMCTS_.*IAC.*\/(ia-case-api|ia-shared-infrastructure|ia-ccd-e2e-tests)\/master
+        name: IA
+        recurse: true
+        title: I & A Dashboard


### PR DESCRIPTION
### WHAT?

Added builds for SSCS and IA to new dashboards by updating cac-prod.yml 

### WHY?

So that if Jenkins is restarted / rebuilt the dashboards are not lost.