### PR TITLE
updated IA dashboard via cac-prod.yml to include latest services

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -55,7 +55,7 @@ jenkins:
         title: SSCS Dashboard
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*IAC.*\/(ia-case-api|ia-shared-infrastructure|ia-ccd-e2e-tests)\/master
+          ^HMCTS_.*IAC.*\/(ia-case-api|ia-case-documents-api|ia-case-notifications-api|ia-shared-infrastructure|ia-ccd-e2e-tests)\/master
         name: IA
         recurse: true
         title: I & A Dashboard

--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -55,7 +55,7 @@ jenkins:
         title: SSCS Dashboard
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*IAC.*\/(ia-case-api|ia-case-documents-api|ia-case-notifications-api|ia-shared-infrastructure|ia-ccd-e2e-tests)\/master
+          ^HMCTS_.*IAC.*\/.+\/master
         name: IA
         recurse: true
         title: I & A Dashboard


### PR DESCRIPTION
This change adds the latest I&A services `ia-case-documents-api` and `ia-case-notifications-api` to the I&A build monitor
