### PR TITLE
Force master for pipeline

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -178,6 +178,7 @@ unclassified:
       - name: 'Infrastructure'
         includeInChangesets: false
         defaultVersion: master
+        allowVersionOverride: false
         retriever:
           modernSCM:
             scm:

--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -189,6 +189,7 @@ unclassified:
       - name: 'Pipeline'
         includeInChangesets: false
         defaultVersion: master
+        allowVersionOverride: false
         retriever:
           modernSCM:
             scm:


### PR DESCRIPTION
Prevent teams from specifying different non-approved branches of the cnp-jenkins-library for building their apps on production jenkins