### PR TITLE
Add cmc-citizen-frontend to prod build monitor

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -23,7 +23,7 @@ jenkins:
         name: all
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*(Platform|CNP).*\/(draft-store|cmc-pdf-service|feature-toggle-api|private-beta-invitation-service|service-auth-provider-app|spring-boot-template|cnp-rhubarb-recipes-service)\/master
+          ^HMCTS_.*(Platform|CNP).*\/(cmc-citizen-frontend|draft-store|cmc-pdf-service|feature-toggle-api|private-beta-invitation-service|service-auth-provider-app|spring-boot-template|cnp-rhubarb-recipes-service)\/master
         name: Platform
         recurse: true
         title: Platform

--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -23,7 +23,7 @@ jenkins:
         name: all
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*(Platform|CNP).*\/(cmc-citizen-frontend|draft-store|cmc-pdf-service|feature-toggle-api|private-beta-invitation-service|service-auth-provider-app|spring-boot-template|cnp-rhubarb-recipes-service)\/master
+          ^HMCTS_.*(Platform|CNP).*\/(draft-store|cmc-pdf-service|feature-toggle-api|private-beta-invitation-service|service-auth-provider-app|spring-boot-template|cnp-rhubarb-recipes-service)\/master
         name: Platform
         recurse: true
         title: Platform
@@ -129,6 +129,12 @@ jenkins:
         name: ETHOS
         recurse: true
         title: ETHOS
+    - buildMonitor:
+        includeRegex: >-
+          ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend)\/master
+        name: CMC
+        recurse: true
+        title: CMC
   authorizationStrategy:
     globalMatrix:
       grantedPermissions:


### PR DESCRIPTION
Adding `cmc-citizen-frontend` to buildMonitor in preparation for nightly jenkins pipeline.