### PR TITLE
Add legal-frontend and claim-store to prod

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -131,7 +131,7 @@ jenkins:
         title: ETHOS
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend|cmc-legal-frontend|cmc-claim-store)\/master
+          ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend|cmc-legal-rep-frontend|cmc-claim-store|cmc-shared-infrastructure)\/master
         name: CMC
         recurse: true
         title: CMC

--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -131,7 +131,7 @@ jenkins:
         title: ETHOS
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend)\/master
+          ^HMCTS_.*(CMC).*\/(cmc-citizen-frontend|cmc-legal-frontend|cmc-claim-store)\/master
         name: CMC
         recurse: true
         title: CMC


### PR DESCRIPTION
Adding missing CMC projects - MichaelO is taking care of adding nightly security scanning e.g.:

https://github.com/hmcts/cmc-claim-store/pull/764