### PR TITLE
Update cred-sauce.groovy

### DIFF
--- a/roles/jenkins/files/cred-sauce.groovy
+++ b/roles/jenkins/files/cred-sauce.groovy
@@ -14,6 +14,7 @@ def credential = new SauceCredentials(
         "${cred_id}",
         "${cred_user}",
         "${cred_secret}",
+        "${cred_eudc}",
         "${cred_desc}"
 )
 


### PR DESCRIPTION
After updating to latest Sauce on demand plugin it requires a eu data center to be set in credentials.