### PR TITLE
Enable rpa-dg-docassembly-api deployments to prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -119,3 +119,4 @@ prod:
   - repo: https://github.com/hmcts/sscs-track-your-appeal-frontend.git
   - repo: https://github.com/hmcts/sscs-track-your-appeal-notifications.git
   - repo: https://github.com/hmcts/sscs-tribunals-case-api.git
+  - repo: https://github.com/hmcts/rpa-dg-docassembly-api.git


### PR DESCRIPTION
Notes:
* rpa-dg-docassembly-api is ready to be deployed to production alongside CMC
