### PR TITLE
Added azure template deployment to approval list

### DIFF
--- a/terraform-infra-approvals/bulk-scan-processor.json
+++ b/terraform-infra-approvals/bulk-scan-processor.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {"type": "azurerm_template_deployment"}
+  ],
+  "module_calls": []
+}
+

--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -5,8 +5,7 @@
     {"type": "azurerm_application_insights"},
     {"type": "azurerm_storage_account"},
     {"type": "azurerm_storage_container"},
-    {"type": "random_string"},
-    {"type": "azurerm_template_deployment"}
+    {"type": "random_string"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},

--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -5,7 +5,8 @@
     {"type": "azurerm_application_insights"},
     {"type": "azurerm_storage_account"},
     {"type": "azurerm_storage_container"},
-    {"type": "random_string"}
+    {"type": "random_string"},
+    {"type": "azurerm_template_deployment"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},


### PR DESCRIPTION

* Bulk scan uses `azurerm_template_deployment` for api management.

* Adding it to the approval list as per the deprecation warnings raised on slack channel.
