### PR TITLE
ccd-waf branch to infra approvals list

### DIFF
--- a/terraform-infra-approvals/ccd-shared-infrastructure.json
+++ b/terraform-infra-approvals/ccd-shared-infrastructure.json
@@ -3,6 +3,7 @@
   "module_calls": [
     {"source":  "git@github.com:hmcts/cnp-module-adf?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-waf?ref=ccd/CHG0033576"},
+    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=ccd-waf"},
     {"source":  "git@github.com:hmcts/cnp-module-storage-account.git?ref=0.0.1"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=curator"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=master"},


### PR DESCRIPTION
Added a branch reference which puts CCD in Prevention mode with fixed list of excluded rules. https://tools.hmcts.net/jira/browse/RDM-3807