### PR TITLE
Revert "Added bulk scan pay processor to approval list"

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -5,7 +5,6 @@ prod:
   - repo: https://github.com/hmcts/bar-web.git
   - repo: https://github.com/hmcts/bulk-scan-orchestrator.git
   - repo: https://github.com/hmcts/bulk-scan-processor.git
-  - repo: https://github.com/hmcts/bulk-scan-payment-processor.git
   - repo: https://github.com/hmcts/bulk-scan-shared-infrastructure.git
   - repo: https://github.com/hmcts/ccd-admin-web.git
   - repo: https://github.com/hmcts/ccd-admin-web-api.git


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-config#315

Not needed yet on prod . Reverting it so that pipeline will skip deployment on prod