### PR TITLE
added waf branch to ccpay infra approvals list

### DIFF
--- a/terraform-infra-approvals/ccpayfr-shared-infrastructure.json
+++ b/terraform-infra-approvals/ccpayfr-shared-infrastructure.json
@@ -1,0 +1,7 @@
+{
+  "resources": [],
+  "module_calls": [
+    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=ccd/CHG0033576"}
+  ]
+}
+


### PR DESCRIPTION
Hi Venny,

For our CCPAYFR-SHARED-INFRASTRUCTURE build is failing due to the detection branch not allowed,
I have made changes to allow ref=ccd/CHG0033576  branch.

Can you please review and approve the same?

Kind Regards,
Amit

