### PR TITLE
added RDM-6000 branch temporarily to test elk changes

### DIFF
--- a/terraform-infra-approvals/ccd-elastic-search.json
+++ b/terraform-infra-approvals/ccd-elastic-search.json
@@ -7,6 +7,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=curator"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=ES-7x-Upgrade"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=master"},
+    {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=RDM-6000"},
     {"source":  "git@github.com:hmcts/cnp-module-logstash.git?ref=master"}
   ]
 }


### PR DESCRIPTION
I would like to test elk changes in the branch RDM-6000.  But sandbox environment is broken at the moment. So, temporarily added this to infra approvals list to test the elk changes in perftest environment. 