### PR TITLE
Custom commit status per organisation

### DIFF
--- a/jobdsl/organisations.groovy
+++ b/jobdsl/organisations.groovy
@@ -145,6 +145,17 @@ Closure githubOrg(Map args = [:]) {
                     strategyId(1)
                 }
 
+                if (isSandbox() || config.nightly) {
+                    def label = isSandbox() && !config.nightly ? "Jenkins - sandbox" : null
+                    if (label == null) {
+                        label = isSandbox() ? "Jenkins - sandbox nightly" : "Jenkins - nightly"
+                    }
+                    traits << 'org.jenkinsci.plugins.githubScmTraitNotificationContext.NotificationContextTrait' {
+                        contextLabel(label)
+                        typeSuffix(false)
+                    }
+                }
+
                 // prevent builds triggering automatically from SCM push for sandbox and nightly builds
                 if ((isSandbox() || config.nightly) && !config.disableNamedBuildBranchStrategy) {
                     node / buildStrategies / 'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl'(plugin: 'basic-branch-build-strategies@1.1.1') {

--- a/playbook.yml
+++ b/playbook.yml
@@ -68,6 +68,7 @@
       - { name: github-api, version: "1.95" }
       - { name: github-branch-source, version: "2.5.8" }
       - { name: github, version: "1.29.5" }
+      - { name: github-scm-trait-notification-context, version: "1.1" }
       - { name: git-server, version: "1.8" }
       - { name: git, version: "3.121" }
       - { name: greenballs, version: "1.15" }


### PR DESCRIPTION
Prevents clobbering of main prod jenkins status by other builds such as
nightly or sandbox

Tested on draft-store:
![image](https://user-images.githubusercontent.com/21194782/66733285-f403d200-ee56-11e9-9126-415261163e7c.png)


Prod jenkins main check isn't renamed at it's a required branch all over the place this will move everything else