### PR TITLE
Add cnp-idam-packer

### DIFF
--- a/terraform-infra-approvals/cnp-idam-packer.json
+++ b/terraform-infra-approvals/cnp-idam-packer.json
@@ -1,0 +1,5 @@
+{
+  "resources": [
+      {"type": "azurerm_resource_group"}
+  ]
+}


### PR DESCRIPTION
Adding cnp-idam-packer to allow Forgerock images to be built

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
