### PR TITLE
Add reform-scan product in team-config

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -144,6 +144,12 @@ bulk-scan:
   slack:
     contact_channel: "#rbs"
     build_notices_channel: "#bsp-build-notices"
+reform-scan: # separate `bulk-scan` product copy since #349
+  team: "Bulk Scanning and Printing"
+  namespace: "bsp"
+  slack:
+    contact_channel: "#rbs"
+    build_notices_channel: "#bsp-build-notices"
 rpe:
   team: "Software Engineering"
   namespace: "rpe"


### PR DESCRIPTION
Missed this config during #349 

Reference to the build: https://build.platform.hmcts.net/view/BSP/job/HMCTS_BSP/job/blob-router-service/job/master/1/console