### PR TITLE
Fix namespace for `reform-scan` "team"

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -146,7 +146,7 @@ bulk-scan:
     build_notices_channel: "#bsp-build-notices"
 reform-scan: # separate `bulk-scan` product copy since #349
   team: "Bulk Scanning and Printing"
-  namespace: "bsp"
+  namespace: "reform-scan"
   slack:
     contact_channel: "#rbs"
     build_notices_channel: "#bsp-build-notices"


### PR DESCRIPTION
For this project separate managed identity was created under `reform-scan` name but config was not reflected after copying same block of `bsp`