### PR TITLE
Added Bulkscanning App to allow build infra

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -126,3 +126,4 @@ prod:
   - repo: https://github.com/hmcts/rpa-native-pdf-annotator-app.git
   - repo: https://github.com/hmcts/ccpay-payment-api-gateway.git
   - repo: https://github.com/hmcts/ctsc-work-allocation.git
+  - repo: https://github.com/hmcts/ccpay-bulkscanning-app.git


### PR DESCRIPTION
Currently entry is missing to build infrastructure

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
