### PR TITLE
updated sauce-on-demand plugin

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -115,7 +115,7 @@
       - { name: pubsub-light, version: "1.13" }
       - { name: run-condition, version: "1.2" }
       - { name: saml, version: "1.1.3" }
-      - { name: sauce-ondemand, version: "1.186" }
+      - { name: sauce-ondemand, version: "1.187" }
       - { name: scm-api, version: "2.6.3" }
       - { name: script-security, version: "1.66" }
       - { name: simple-theme-plugin, version: "0.5.1" }


### PR DESCRIPTION
Resolves # issue with sauce-on-demand plugin for cross browser tests


 A just-in-time binding to com.saucelabs.jenkins.pipeline.SauceConnectStep was already configured on a parent injector.
  at org.jenkinsci.plugins.workflow.steps.ContextParameterModule.configure(ContextParameterModule.java:45)