### PR TITLE
Added reform scan shared infra and blob router to deploy them into prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -6,6 +6,8 @@ prod:
   - repo: https://github.com/hmcts/bulk-scan-orchestrator.git
   - repo: https://github.com/hmcts/bulk-scan-processor.git
   - repo: https://github.com/hmcts/bulk-scan-shared-infrastructure.git
+  - repo: https://github.com/hmcts/blob-router-service.git
+  - repo: https://github.com/hmcts/reform-scan-shared-infra.git
   - repo: https://github.com/hmcts/ccd-admin-web.git
   - repo: https://github.com/hmcts/ccd-admin-web-api.git
   - repo: https://github.com/hmcts/ccd-api-gateway.git


### PR DESCRIPTION
- Added blob router and reform scan shared infrastructure to approval list as we need  to ITHC on prod environment.

- Traffic is not going to be live and this is just for ITHC testing so that we can do pen testing for crime VPN.