### PR TITLE
sandbox-build agents bumped to nodejs v12x LTS / sig img v1.3.0

### DIFF
--- a/cac-sandbox.yml
+++ b/cac-sandbox.yml
@@ -55,7 +55,7 @@ jenkins:
         executeInitScriptAsRoot: true
         existingStorageAccountName: "mgmtvmimgstoresandbox"
         imageReference:
-          id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cnp-vmimages-sandbox/providers/Microsoft.Compute/images/cnp-jenkins-agent74-20191202093607"
+          id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/cnp-vmimages-sandbox/providers/Microsoft.Compute/images/cnp-jenkins-agent74-20200124155803"
         imageTopLevelType: "advanced"
         initScript: |-
           usermod -a -G docker jenkinsssh


### PR DESCRIPTION
**JIRA link (if applicable)**
[AB#732](https://dev.azure.com/hmcts/90472b63-dc8d-4ae6-8819-a32bd211e914/_workitems/edit/732)

**Change description**
Bump up jenkins-agent sandbox-build to nodejs v12.x LTS / sig v1.3.0

Does this PR introduce a breaking change? (check one with "x")
[x ] Yes
[ ] No