### PR TITLE
Add test branch of module-waf to ccd-shared-infra

### DIFF
--- a/terraform-infra-approvals/ccd-shared-infrastructure.json
+++ b/terraform-infra-approvals/ccd-shared-infrastructure.json
@@ -4,6 +4,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-adf?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-waf?ref=ccd/CHG0033576"},
     {"source":  "git@github.com:hmcts/cnp-module-waf?ref=ccd-waf"},
+    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=njrich28-patch-1"},
     {"source":  "git@github.com:hmcts/cnp-module-storage-account.git?ref=0.0.1"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=curator"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=master"},


### PR DESCRIPTION
Just adding this temporarily to allow for testing of module in perftest because it's already in a state to be tested there

