### PR TITLE
Added whitelisting for palo module branch for bulk scan shared infra

### DIFF
--- a/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
+++ b/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
@@ -3,5 +3,7 @@
     {"type": "azurerm_subnet_network_security_group_association"},
     {"type": "azurerm_network_security_group"}
   ],
-  "module_calls": []
+  "module_calls": [
+   {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=master"}
+  ]
 }

--- a/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
+++ b/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
@@ -4,6 +4,6 @@
     {"type": "azurerm_network_security_group"}
   ],
   "module_calls": [
-   {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=master"}
+   {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"}
   ]
 }


### PR DESCRIPTION
- Temporarily adding exclusion to test pip upgrade branch https://github.com/hmcts/bulk-scan-shared-infrastructure/pull/160

- Changes  https://github.com/hmcts/cnp-module-palo-alto/pull/24 are not yet merged as it may impact other consumers of Palo module.