### PR TITLE
Add palo-alto module branch with upgraded pip to reform-scan tf approvals

### DIFF
--- a/terraform-infra-approvals/reform-scan-shared-infra.json
+++ b/terraform-infra-approvals/reform-scan-shared-infra.json
@@ -1,0 +1,6 @@
+{
+  "resources": [],
+  "module_calls": [
+    {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"}
+  ]
+}


### PR DESCRIPTION
Without pip upgrade, palo-alto module fails at terraform apply stage. Same change was required (and made) for bulk-scan-shared-infrastructure.