### PR TITLE
Fix regex for BSP config

### DIFF
--- a/cac-prod.yml
+++ b/cac-prod.yml
@@ -45,7 +45,7 @@ jenkins:
         title: Platform
     - buildMonitor:
         includeRegex: >-
-          ^HMCTS_.*BSP.*\/(blob-router-service|bulk-scan-.*|reform-scan-*|send-letter-client|send-letter-service)\/master
+          ^HMCTS_.*BSP.*\/(blob-router-service|bulk-scan-.*|reform-scan-.*|send-letter-client|send-letter-service)\/master
         name: BSP
         recurse: true
         title: BSP


### PR DESCRIPTION
Missing `.`