### PR TITLE
Add 2.x azure terraform compatible key vault branch

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -16,6 +16,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-api-mgmt-api-policy?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-key-vault?ref=master"},
+    {"source":  "git@github.com:hmcts/cnp-module-key-vault?ref=change-to-sku-name"},
     {"source":  "git@github.com:hmcts/cnp-module-shutterpage?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-storage?ref=master"},


### PR DESCRIPTION
Until we manage to do the breaking change we may as well allow people to use 2.x

https://github.com/hmcts/cnp-module-key-vault/pull/22