### PR TITLE
Added PDF threat exclusion branch to reform and bulkscan

### DIFF
--- a/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
+++ b/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
@@ -4,7 +4,7 @@
     {"type": "azurerm_network_security_group"}
   ],
   "module_calls": [
-   {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"},
+   {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"},
    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=CHG5001024"}
   ]
 }

--- a/terraform-infra-approvals/reform-scan-shared-infra.json
+++ b/terraform-infra-approvals/reform-scan-shared-infra.json
@@ -1,6 +1,6 @@
 {
   "resources": [],
   "module_calls": [
-    {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=test-pip-upgrade"}
+    {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"}
   ]
 }


### PR DESCRIPTION
* Previous pip upgrade branch changes have been merged to master now 
* `add-pdf-threat-exclusion` includes adding exclusion for PDF threat id 34805 https://github.com/hmcts/cnp-module-palo-alto/tree/add-pdf-threat-exclusion
More details are included here https://tools.hmcts.net/jira/browse/BPS-1117
* This exclusion is currently applied by Devops manually on palo instances so it is currently in prod and being approved by IA.
* We can't merge the exclusion change to master as it will apply to all the consumers of palo module.
* Also soon we are migrating to shared Palos so this should be just an interim solution.
