### PR TITLE
Allow for using terraform-module-servicebus-queue branch with count param

### DIFF
--- a/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
+++ b/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
@@ -5,6 +5,7 @@
   ],
   "module_calls": [
    {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"},
+   {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=feature/add-count-input-variable"},
    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=CHG5001024"}
   ]
 }


### PR DESCRIPTION
Allow for using terraform-module-servicebus-queue branch with count parameter. The change in the module needs to be verified on a separate branch first, so that changes don't get deployed to aat and prod. Once that's done and the module is updated, this PR will be reverted.