### PR TITLE
Update idam-web-public.json

### DIFF
--- a/terraform-infra-approvals/idam-web-public.json
+++ b/terraform-infra-approvals/idam-web-public.json
@@ -1,7 +1,8 @@
 {
   "resources": [],
   "module_calls": [
-    {"source":  "git@github.com:hmcts/cnp-module-webapp?ref=SIDM-3089"}
+    {"source":  "git@github.com:hmcts/cnp-module-webapp?ref=SIDM-3089"},
+    {"source":  "git@github.com:hmcts/cnp-module-redis?ref=azurerm_redis_cache-resource"}
   ]
 }
 


### PR DESCRIPTION
Resolves SIDM-4235

Notes:
* tf 0.11.*
* Use azurerm redis cache resource instead of the azure resource manager deployment templates.
