### PR TITLE
Use exclusion branch containing exclusion only for 920420

### DIFF
--- a/terraform-infra-approvals/reform-scan-shared-infra.json
+++ b/terraform-infra-approvals/reform-scan-shared-infra.json
@@ -5,6 +5,6 @@
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"},
-    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=CHG5001024"}
+    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=add-exclusion-rule"}
   ]
 }


### PR DESCRIPTION

* Mistakenly used wrong exclusion branch previously which had exclusion for 3 rules and was used for bulk scan.
* Reform scan WAF only needs to exclude one rule 920420
