### PR TITLE
Add cnp-module-vnet to tf infra approvals

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -32,6 +32,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-app-service-plan?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-waf?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-trafficmanager-endpoint?ref=master"},
-    {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"}
+    {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"},
+    {"source":  "git@github.com:hmcts/cnp-module-vnet?ref=master"}
   ]
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Related to cnp-core-infra cleanup ticket which uses vnet module
* https://github.com/hmcts/cnp-module-vnet
