### PR TITLE
temporarily revert finrem back to the jenkins agent

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -121,7 +121,6 @@ dg:
 finrem:
   team: "Financial Remedy"
   namespace: "financial-remedy"
-  agent: "k8s-agent"
   slack:
     contact_channel: "#finrem-dev"
     build_notices_channel: "#finrem-dev"


### PR DESCRIPTION
Notes:
*
*
*
while k8 agents are having connectivity issues this is to revert finrem back to using the jenkisn agent to unblock our pipelines. It will be reverted back to K8 agents when their issues are resolved