### PR TITLE
Update bulk-scan-shared-infrastructure.json

### DIFF
--- a/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
+++ b/terraform-infra-approvals/bulk-scan-shared-infrastructure.json
@@ -1,7 +1,8 @@
 {
   "resources": [
     {"type": "azurerm_subnet_network_security_group_association"},
-    {"type": "azurerm_network_security_group"}
+    {"type": "azurerm_network_security_group"},
+    {"type": "azurerm_template_deployment"}
   ],
   "module_calls": [
    {"source":  "git@github.com:hmcts/cnp-module-palo-alto?ref=add-pdf-threat-exclusion"},


### PR DESCRIPTION
Allow ARM templates as ability to deploy private endpoints is a preview feature in the latest AzureRM provider, which requires upgrading all the existing TF to 0.12. This is beyond the scope of the current work.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
