### PR TITLE
PCQ-678: Update to allow PCQ to add lifecycle rules to blob storage.

### DIFF
--- a/terraform-infra-approvals/pcq-shared-infrastructure.json
+++ b/terraform-infra-approvals/pcq-shared-infrastructure.json
@@ -1,0 +1,6 @@
+{
+  "resources": [
+    {"type": "azurerm_storage_management_policy"}
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
Resolves https://tools.hmcts.net/jira/browse/PCQ-678.

Notes:
* PCQ Blob Storage requires all blobs to expire (be deleted) after 90 days.
* Terraform change adds rule azurerm_storage_management_policy to allow PCQ to manage expiration rules.
