### PR TITLE
PAY-3742: Whitelisting for Bar shared infrastructure

### DIFF
--- a/terraform-infra-approvals/bar-shared-infrastructure.json
+++ b/terraform-infra-approvals/bar-shared-infrastructure.json
@@ -1,0 +1,6 @@
+{
+  "resources": [
+    {"type": "azurerm_template_deployment"}
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
58:25  this repo is using a terraform resource that is not allowed,
**16:58:25  whitelists are stored in https://github.com/hmcts/cnp-jenkins-config/tree/master/terraform-infra-approvals
16:58:25  send a pull request if you think this is in error.
16:58:25  non whitelisted resources:**
16:58:25  ```
16:58:25  error loading module [.]: Invalid argument name: Argument names must not be quoted. (and 1 other messages)
16:58:25  Error loading infra definition at .