### PR TITLE
Allow azurerm_monitor_action_group module

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -10,7 +10,8 @@
     {"type": "azurerm_subnet"},
     {"type": "azurerm_api_management"},
     {"type": "azurerm_management_lock"},
-    {"type": "azurerm_management_group"}
+    {"type": "azurerm_management_group"},
+    {"type": "azurerm_monitor_action_group"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},


### PR DESCRIPTION

Notes:
I'd like to use the azurerm_monitor_action_group to enable monitoring functionality
*
*
*
