### PR TITLE
Revert "SSCS-7330 SSCS MYA (#606)"

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -130,7 +130,6 @@ prod:
   - repo: https://github.com/hmcts/sscs-ccd-callback-orchestrator.git
   - repo: https://github.com/hmcts/sscs-cor-backend.git
   - repo: https://github.com/hmcts/sscs-cor-frontend.git
-  - repo: https://github.com/hmcts/sscs-mya-frontend.git
   - repo: https://github.com/hmcts/sscs-evidence-share.git
   - repo: https://github.com/hmcts/sscs-shared-infrastructure.git
   - repo: https://github.com/hmcts/sscs-submit-your-appeal.git
@@ -147,9 +146,9 @@ prod:
   - repo: https://github.com/hmcts/ccpay-bulkscanning-app.git
   - repo: https://github.com/hmcts/bulk-scan-payment-processor.git
   - repo: https://github.com/hmcts/reform-scan-notification-service.git
-  - repo: https://github.com/hmcts/em-icp-api.git
+  - repo: https://github.com/hmcts/em-icp-api.git 
   - repo: https://github.com/hmcts/camunda-bpm.git
   - repo: https://github.com/hmcts/fact-shared-infrastructure.git
   - repo: https://github.com/hmcts/fact-frontend.git
-  - repo: https://github.com/hmcts/fact-admin.git
+  - repo: https://github.com/hmcts/fact-admin.git 
   - repo: https://github.com/hmcts/fact-api.git

--- a/team-config.yml
+++ b/team-config.yml
@@ -384,14 +384,6 @@ sscs-cor:
     build_notices_channel: "#sscs-tech"
   tags:
     application: social-service-child-support
-sscs-mya:
-  team: "SSCS"
-  namespace: "sscs"
-  slack:
-    contact_channel: "#sscs-tech"
-    build_notices_channel: "#sscs-tech"
-  tags:
-    application: social-service-child-support
 sscs-tya:
   team: "SSCS"
   namespace: "sscs"


### PR DESCRIPTION
SSCS COR Service no longer being renamed to MYA. Reverting Change

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
