### PR TITLE
Ignore stale branches from getting built

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -167,6 +167,12 @@ Closure githubOrg(Map args = [:]) {
                     skipProgressUpdates(true)
                 }
 
+                if (!config.nightly) {
+                    traits << 'org.jenkinsci.plugins.scm_filter.GitHubAgedRefsTrait' {
+                        retentionDays(30)
+                    }
+                }
+
                 // prevent builds triggering automatically from SCM push for sandbox and nightly builds
                 if ((runningOnSandbox || config.nightly) && !config.disableNamedBuildBranchStrategy) {
                     node / buildStrategies / 'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl'(plugin: 'basic-branch-build-strategies@1.1.1') {


### PR DESCRIPTION
* It deletes branches/ PRs which are not updated in last 30 days from Jenkins
* Doesn't apply for Jenkins as it's a valid scenario.
