### PR TITLE
Allows send-letter-service to add role assignments

### DIFF
--- a/terraform-infra-approvals/send-letter-service.json
+++ b/terraform-infra-approvals/send-letter-service.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {"type": "azurerm_role_assignment"}
+  ],
+  "module_calls": []
+}
+


### PR DESCRIPTION
send-letter-service wants to assign the roles
- Storage Blob Delegator
- Storage Blob Data Contributor

to its Managed Identity.