### PR TITLE
Skip aged ref for library test

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -55,6 +55,7 @@ if (isSandbox()) {
             jenkinsfilePath                : 'Jenkinsfile_pipeline_test',
             suppressDefaultJenkinsfile     : true,
             disableNamedBuildBranchStrategy: true,
+            disableAgedRefsBranchStrategy  : true,
             credentialId                   : 'hmcts-jenkins-cnp'
     ]
     githubOrg(pipelineTestOrg).call()
@@ -167,7 +168,7 @@ Closure githubOrg(Map args = [:]) {
                     skipProgressUpdates(true)
                 }
 
-                if (!config.nightly) {
+                if (!config.nightly && !config.disableAgedRefsBranchStrategy) {
                     traits << 'org.jenkinsci.plugins.scm_filter.GitHubAgedRefsTrait' {
                         retentionDays(30)
                     }


### PR DESCRIPTION

* Had a failure this morning with Jenkins Library pipeline Test as shared-infra repo wasn't touched for more than a month. 
