### PR TITLE
SIDM-5937: Allowing idam-master to control routes

### DIFF
--- a/terraform-infra-approvals/idam-master.json
+++ b/terraform-infra-approvals/idam-master.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {"type": "azurerm_route_table"},
+    {"type": "azurerm_route"}
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
Required as new AKS cluster is routed through the new firewalls, this
allows the FR subnets to use the correct route back to AKS

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
