### PR TITLE
SIDM-5937: missed one

### DIFF
--- a/terraform-infra-approvals/idam-master.json
+++ b/terraform-infra-approvals/idam-master.json
@@ -2,6 +2,7 @@
   "resources": [
     {"type": "azurerm_route_table"},
     {"type": "azurerm_route"}
+    {"type": "azurerm_subnet_route_table_association"}
   ],
   "module_calls": []
 }


### PR DESCRIPTION
Missed azurerm_subnet_route_table_association from vnet.tf subnet
assignments

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
