### PR TITLE
Add am-role-assignment-refresh-batch for prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -3,6 +3,7 @@ prod:
   - repo: https://github.com/hmcts/am-role-assignment-service.git
   - repo: https://github.com/hmcts/am-role-assignment-batch-service.git
   - repo: https://github.com/hmcts/am-org-role-mapping-service.git
+  - repo: https://github.com/hmcts/am-role-assignment-refresh-batch.git
   - repo: https://github.com/hmcts/aac-manage-case-assignment.git
   - repo: https://github.com/hmcts/bar-api.git
   - repo: https://github.com/hmcts/bar-shared-infrastructure.git


### PR DESCRIPTION
Adding am-role-assignment-refresh-batch service for production deployment.

Notes:
* SecOps approval is attached in the JIRA ticket https://tools.hmcts.net/jira/browse/AM-1430