### PR TITLE
Exclude the case hq emulator repo

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -25,7 +25,7 @@ List<Map> orgs = [
         [name: 'IAC', regex: 'ia.*'],
         [name: 'IDAM', regex: '(idam-.*|cnp-idam-.*)'],
         [name: 'MI', displayName: 'Management Information'],
-        [name: 'HMI'],
+        [name: 'HMI', regex: 'hmi-(?!case-hq-emulator).*'],
         [name: 'PCQ'],
         [name: 'Platform',credentialId: "hmcts-jenkins-rpe", regex: '(rpe-.*|draft-store.*|cmc-pdf-service|service-auth-provider-.*|spring-boot-template|data-extractor|data-generator|camunda-.*)'],
         [name: 'Probate'],


### PR DESCRIPTION
This will exclude the hmi-case-hq-emulator repo as it is on SDS
