### PR TITLE
Temporarily switch CCD build agent back to centos

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -25,6 +25,7 @@ hmc:
 ccd:
   team: "CCD"
   namespace:  "ccd"
+  agent: "centos"
   slack:
     contact_channel: "#ccd-questions-answers"
     build_notices_channel: "#ccd-master-builds"


### PR DESCRIPTION
Notes:
* This change will be reverted once the CCD Node.js components have been updated to use Node.js version 14 - see CCD-2332 (https://tools.hmcts.net/jira/browse/CCD-2332).
