### PR TITLE
Off boarding Domestic abuse

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -40,7 +40,6 @@ List<Map> orgs = [
         [name: 'NFDIV', displayName: "No Fault Divorce"],
         [name: 'LAU', displayName: "Logs and Audit"],
         [name: 'PRL', displayName: 'Private Law'],
-        [name: 'DA', displayName: 'Domestic Abuse'],
         [name: 'LABS', displayName: 'Labs'],
 ]
 

--- a/team-config.yml
+++ b/team-config.yml
@@ -665,14 +665,6 @@ adoption-ccd-definitions:
     build_notices_channel: "#adoption-tech"
   tags:
     application: adoption-ccd-definitions
-da:
-  team: "Domestic Abuse"
-  namespace:  "domestic-abuse"
-  slack:
-    contact_channel: "#da-tech-notifications"
-    build_notices_channel: "#da-tech-notifications"
-  tags:
-    application: da-cos-api
 labs:
   team: "CNP"
   namespace: "labs"


### PR DESCRIPTION
It has been agreed technically that Domestic Abuse and Child arrangement under PrivateLaw project will use the same codebase. Therefore DA specific configuration is no longer required. Hence, removing Domestic Abuse Jenkins configuration