### PR TITLE
RDCC-4064 adding common data repo approvals

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -122,6 +122,8 @@ prod:
   - repo: https://github.com/hmcts/rd-location-ref-api.git
   - repo: https://github.com/hmcts/rd-location-ref-data-load.git
   - repo: https://github.com/hmcts/rd-caseworker-ref-api.git
+  - repo: https://github.com/hmcts/rd-commondata-api.git
+  - repo: https://github.com/hmcts/rd-commondata-dataload.git
   - repo: https://github.com/hmcts/rpa-coh-continuous-online-resolution.git
   - repo: https://github.com/hmcts/em-ccd-orchestrator.git
   - repo: https://github.com/hmcts/rpa-jui-webapp.git


### PR DESCRIPTION
**Notes:**
1) This will be standard CICD deployment for new ref data application mentioned in file with LD Toggled OFF and no service 
     whitelisted in production.
2) This is being agreed with plats ops team (Benjamin.Neill@HMCTS.NET),  perftest , ITHC and Release team.
3) That OAT and ATO will be part final release when EXUI consumer go live with us in near future.

Please approve this PR.
Thanks.
