### PR TITLE
Added adoption-shared-infrastructure repo to prod whitelist

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -194,3 +194,4 @@ prod:
   - repo: https://github.com/hmcts/prl-cos-api.git
   - repo: https://github.com/hmcts/prl-dgs-api.git
   - repo: https://github.com/hmcts/prl-shared-infrastructure.git
+  - repo: https://github.com/HMCTS/adoption-shared-infrastructure.git


### PR DESCRIPTION
Added adoption-shared-infrastructure repo to prod whitelist

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
