### PR TITLE
DTSPO-6371 - allow hmcts/terraform-module-common-tags

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -49,6 +49,8 @@
     {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-vnet?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"}
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"},
+    {"source":  "https://github.com/hmcts/terraform-module-common-tags.git?ref=master"}
+    
   ]
 }


### PR DESCRIPTION
Allowing common tags to be used globally