### PR TITLE
Remove common tags module

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -49,8 +49,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-vnet?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"},
-    {"source":  "git@github.com:hmcts/terraform-module-common-tags.git?ref=master"}
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"}
     
   ]
 }


### PR DESCRIPTION
not needed on Jenkins use var.common_tags