### PR TITLE
added extra source to camunda shared infra

### DIFF
--- a/terraform-infra-approvals/camunda-shared-infrastructure.json
+++ b/terraform-infra-approvals/camunda-shared-infrastructure.json
@@ -1,6 +1,7 @@
 {
   "resources": [],
   "module_calls": [
-    {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=7.11.1"}
+    {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=7.11.1"},
+    {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=RDM-13038"}
   ]
 }


### PR DESCRIPTION
Added elk RDM-13038 to whitelist for Camunda.

Notes:
*
*
*
