### PR TITLE
DTSPO-6371 - add service bus queue module

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -52,6 +52,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"}
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=DTSPO-6371_azurerm_upgrade"}
     
   ]
 }

--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -51,7 +51,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"}
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=DTSPO-6371_azurerm_upgrade"}
     
   ]


### PR DESCRIPTION
Adding DTSPO-6371_azurerm_upgrade branch on terraform-module-servicebus-queue to global allow list whilst working on DTSPO-6371. This is needed to test upgrading to azurerm 3.x.x