### PR TITLE
updated camunda to use tag of core as per tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -488,7 +488,7 @@ camunda:
     contact_channel: "#platops-help"
     build_notices_channel: "#platops-build-notices"
   tags:
-    application: camunda
+    application: core
 ethos:
   team: "Ethos Replacement"
   namespace: "ethos"


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:

As per https://tools.hmcts.net/jira/browse/DTSPO-7842 and the tagging dictionary the application tag for Camunda has been updated.
