### PR TITLE
updated tag name for family-integration as per tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -696,4 +696,4 @@ fis:
     contact_channel: "#family-integration-devs"
     build_notices_channel: "#family-integration-cicd-notice"
   tags:
-    application: family-integration-stream
+    application: family-integration-systems


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
 For https://tools.hmcts.net/jira/browse/DTSPO-7842 and as per https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1007945237#Taggingv0.4-TaggingDictionary application name has been updated.
