### PR TITLE
updated Family private Law tag to match tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -648,7 +648,7 @@ prl:
     contact_channel: "#prl-tech"
     build_notices_channel: "#prl-tech"
   tags:
-    application: private-law
+    application: family-private-law
 adoption-web:
   team: "Adoption"
   namespace:  "adoption"


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
As per https://tools.hmcts.net/jira/browse/DTSPO-7853, Updated Family Private Law tags to match agreed tag name within tagging dictionary - https://tools.hmcts.net/confluence/display/DCO/Tagging+v0.4
