### PR TITLE
updated Civil Enforcement application tag to match tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -101,7 +101,7 @@ cet:
     contact_channel: "#cet-pipeline"
     build_notices_channel: "#cet-pipeline"
   tags:
-    application: civil-enforcement
+    application: civil-inforcement
 div:
   team: "Divorce"
   namespace: "divorce"


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:

As per https://tools.hmcts.net/jira/browse/DTSPO-8026 updated the application tag for Civil Enforcement to match the agreed name from the tagging dictionary - https://tools.hmcts.net/confluence/display/DCO/Tagging+v0.4
