### PR TITLE
updated snl tag to match agreed tag within tagging dictionary

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -423,7 +423,7 @@ snl:
     contact_channel: "#snl-master-builds"
     build_notices_channel: "#snl-master-builds"
   tags:
-    application: scheduling-and-listing
+    application: schedule-and-listing
 am:
   team: "AM"
   namespace: "am"


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
Updated application tag for snl to match agreed name in the tagging dictionary - https://tools.hmcts.net/confluence/pages/viewpage.action?pageId=1007945237#Taggingv0.4-TaggingDictionary
