### PR TITLE
DTSPO-6371 - delete old branches of servicebus modules

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -48,11 +48,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-trafficmanager-endpoint?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-metric-alert?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-vnet?ref=master"},
-    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=DTSPO-6371_remove_provider"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=DTSPO-6371_azurerm_upgrade"}
+    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"}
     
   ]
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
