### PR TITLE
Updates to include ia-bail case api service

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -91,6 +91,7 @@ prod:
   - repo: https://github.com/hmcts/ia-case-payments-api.git
   - repo: https://github.com/hmcts/ia-case-access-api.git
   - repo: https://github.com/hmcts/ia-task-configuration.git
+  - repo: https://github.com/hmcts/ia-bail-case-api.git
   - repo: https://github.com/hmcts/idam-api.git
   - repo: https://github.com/hmcts/idam-shared-infrastructure.git
   - repo: https://github.com/hmcts/idam-web-admin.git


### PR DESCRIPTION
This is to include ia-bail-case-api into the scope.