### PR TITLE
DTSPO-8049 - updating team name for keda

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -618,7 +618,7 @@ paymentsgw:
   tags:
     application: fees-and-payments
 keda:
-  team: "CNP"
+  team: "Platform Operations"
   namespace: "admin"
   slack:
     contact_channel: "#platops-help"


### PR DESCRIPTION
Updating team name to "Platform Operations" according to DTSPO-8049 
