### PR TITLE
Adds plum to approvals for prod, for testing cluster/traefik upgrades

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -207,3 +207,5 @@ prod:
   - repo: https://github.com/hmcts/et-ccd-callbacks.git
   - repo: https://github.com/hmcts/et-message-handler.git
   - repo: https://github.com/hmcts/et-shared-infrastructure.git
+  - repo: https://github.com/hmcts/cnp-plum-shared-infrastructure.git
+  - repo: https://github.com/hmcts/cnp-plum-recipes-service.git


### PR DESCRIPTION
Notes:
* https://tools.hmcts.net/jira/browse/DTSPO-8117
* Whitelisting for creating prod resources for plum