### PR TITLE
Deploy et-sya and et-sya-api

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -212,3 +212,5 @@ prod:
   - repo: https://github.com/hmcts/sptribs-case-api.git
   - repo: https://github.com/hmcts/fis-shared-infrastructure.git
   - repo: https://github.com/hmcts/family-api-gateway.git
+  - repo: https://github.com/hmcts/et-sya-frontend.git
+  - repo: https://github.com/hmcts/et-sya-api.git


### PR DESCRIPTION
Whitelisting et-sya and et-sya-api repos for https://tools.hmcts.net/confluence/display/RSTR/ET-Rel-2.0.0-+E2E+External+Journey+-+Release+Implementation+Plan
