### PR TITLE
SIDM-8125 Use real certs for preview

### DIFF
--- a/private-dns-config.yml
+++ b/private-dns-config.yml
@@ -11,7 +11,7 @@ subscriptions:
     resourceGroup: core-infra-intsvc-rg
 
   - name: "DTS-CFTPTL-INTSVC"
-    zoneTemplate: '${["plum","sscs"].contains(product) || ["draft-store-service","em-ccdorc", "div-cos","civil-general-applications"].contains(appFullName) ? environment + ".platform.hmcts.net" : "service.core-compute-" + environment + ".internal"}'
+    zoneTemplate: '${["plum","sscs","idam"].contains(product) || ["draft-store-service","em-ccdorc", "div-cos","civil-general-applications"].contains(appFullName) ? environment + ".platform.hmcts.net" : "service.core-compute-" + environment + ".internal"}'
     ttl: 300
     active: true
     consulActive: true


### PR DESCRIPTION
As we have actual services running in the preview cluster (idam-api; idam-web-public; idam-user-dashboard) we would like to use a real certificate to allow easier automated interaction with these services.