### PR TITLE
Add azurerm_web_pubsub to support websockets

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -15,7 +15,8 @@
     {"type": "azurerm_monitor_action_group"},
     {"type": "azurerm_application_insights_web_test"},
     {"type": "azurerm_monitor_action_rule_action_group"},
-    {"type": "azurerm_monitor_metric_alert"}
+    {"type": "azurerm_monitor_metric_alert"},
+    {"type": "azurerm_web_pubsub"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},


### PR DESCRIPTION
Websockets are not currently supported by Azure Frontdoor so it is not possible to host a websocket server inside the CNP. This PR allows the use of [Azure Web Pub Sub](https://azure.microsoft.com/en-us/products/web-pubsub/) so that websocket servers can be created as part of the CNP infrastructure pipelines