### PR TITLE
Add civil-sdt-gateway Terraform infra approval file

### DIFF
--- a/terraform-infra-approvals/civil-sdt-gateway.json
+++ b/terraform-infra-approvals/civil-sdt-gateway.json
@@ -1,0 +1,6 @@
+{
+  "resources": [],
+  "module_calls": [
+    {"source":  "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=api_type"}
+  ]
+}


### PR DESCRIPTION
Added Terraform infra approval file for civil-sdt-gateway.  Initially will be used for testing a change to the cnp-module-api-mgmt-api module.
