### PR TITLE
allowed adding-postgresql-ad-administrator branch

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -53,6 +53,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=json-troubleshooting"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=enable-replicas-master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"}
   ]
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*. In order to allow  testing adding-postgresql-ad-administrator branch
