### PR TITLE
Allows DTSSE shared infra repo to modify the KV access policy

### DIFF
--- a/terraform-infra-approvals/dtsse-shared-infrastructure.json
+++ b/terraform-infra-approvals/dtsse-shared-infrastructure.json
@@ -2,7 +2,8 @@
   "resources": [
     {"type": "azurerm_dashboard_grafana"},
     {"type": "azurerm_role_assignment"},
-    {"type": "azurerm_postgresql_firewall_rule"}
+    {"type": "azurerm_postgresql_firewall_rule"},
+    {"type": "azurerm_key_vault_access_policy"}
   ],
   "module_calls": []
 }


### PR DESCRIPTION
Notes:
* This is to allow this PR to run: https://github.com/hmcts/dtsse-shared-infrastructure/pull/11/files 
* This is needed for the dtsse-ardoq-adapter to run in ptl-intsvc but use our teams central KV
