### PR TITLE
Deploys a DTSSE KV to prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -215,3 +215,4 @@ prod:
   - repo: https://github.com/hmcts/family-api-gateway.git
   - repo: https://github.com/hmcts/et-sya-frontend.git
   - repo: https://github.com/hmcts/et-sya-api.git
+  - repo: https://github.com/hmcts/dtsse-shared-infrastructure.git


### PR DESCRIPTION
grafana and postgres are disabled in prod via tfvars.

This is needed to allow https://github.com/hmcts/dtsse-ardoq-adapter/ to be deployed to prod later
