### PR TITLE
Revert "Fix component name for civil-ccd"

### DIFF
--- a/private-dns-config.yml
+++ b/private-dns-config.yml
@@ -11,7 +11,7 @@ subscriptions:
     resourceGroup: core-infra-intsvc-rg
 
   - name: "DTS-CFTPTL-INTSVC"
-    zoneTemplate: '${["plum","sscs","idam"].contains(product) || ["draft-store-service","em-ccdorc", "div-cos","civil-general-applications", "civil-service", "civil-ccd"].contains(appFullName) ? environment + ".platform.hmcts.net" : "service.core-compute-" + environment + ".internal"}'
+    zoneTemplate: '${["plum","sscs","idam"].contains(product) || ["draft-store-service","em-ccdorc", "div-cos","civil-general-applications", "civil-service", "civil-ccd-definition"].contains(appFullName) ? environment + ".platform.hmcts.net" : "service.core-compute-" + environment + ".internal"}'
     ttl: 300
     active: true
     consulActive: true


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-config#838

We have to revert temporarily to get IDAM whitelisting first.