### PR TITLE
add div-cos to allow for v14 postgres branch

### DIFF
--- a/terraform-infra-approvals/div-case-orchestration-service.json
+++ b/terraform-infra-approvals/div-case-orchestration-service.json
@@ -1,0 +1,6 @@
+{
+  "resources": [],
+  "module_calls": [
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=db-collation"}
+  ]
+}


### PR DESCRIPTION
Creating a seperate approval file as div-shared-infra isn't passing to div-cos for v14 changes