### PR TITLE
DTSPO-7637 - Update team-config.yml

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -375,7 +375,7 @@ crumble:
   azure_ad_group: "DTS Platform Operations"
   slack:
     contact_channel: "#platops-help"
-    build_notices_channel: "#platops-build-notices"
+    build_notices_channel: "#test-ek-2"
   tags:
     application: core
 plum-shared-infrastructure:


### PR DESCRIPTION
Update team-config.yml so crumble build notices channel is set to test channel where jenkins bot has not been invited.

To be used to test change to jenkins library that will fail pipelines when the bot is not in the channel.
