### PR TITLE
Whitelist cnp-module-storage-account for sscs-shared-infrastructure

### DIFF
--- a/terraform-infra-approvals/sscs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sscs-shared-infrastructure.json
@@ -5,6 +5,7 @@
     "module_calls": [
       {"source":  "git@github.com:hmcts/cnp-module-action-group?ref=SSCS-10638-output_id"},
       {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=sscs-remove-default-provider"},
-      {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=sscs-remove-default-provider"}
+      {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=sscs-remove-default-provider"},
+      {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=feature/sftp-support"}
     ]
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Follow up from #868 
*
*
