### PR TITLE
DFR-1944: Fully decommission dgcs and emcs for FR

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -78,8 +78,6 @@ prod:
   - repo: https://github.com/hmcts/ecm-shared-infrastructure.git
   - repo: https://github.com/hmcts/feature-toggle-api.git
   - repo: https://github.com/hmcts/finrem-case-orchestration-service.git
-  - repo: https://github.com/hmcts/finrem-document-generator-client.git
-  - repo: https://github.com/hmcts/finrem-evidence-management-client-api.git
   - repo: https://github.com/hmcts/finrem-notification-service.git
   - repo: https://github.com/hmcts/finrem-shared-infrastructure.git
   - repo: https://github.com/hmcts/fpl-ccd-configuration.git


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*https://tools.hmcts.net/jira/browse/DFR-1944

These two repo had been absorb in finrem-case-orchestration-service service.

Fully decommission finrem-document-generator-serivce and finrem-evidence-management-client-service 

    Archive githup repos
    Remove from Jenkins dashboards
    Remove from Jenkins pipeline builds
    Ensure pods are not deployed in all envs

