### PR TITLE
DFR-1997: decommission-notification-service

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -78,7 +78,6 @@ prod:
   - repo: https://github.com/hmcts/ecm-shared-infrastructure.git
   - repo: https://github.com/hmcts/feature-toggle-api.git
   - repo: https://github.com/hmcts/finrem-case-orchestration-service.git
-  - repo: https://github.com/hmcts/finrem-notification-service.git
   - repo: https://github.com/hmcts/finrem-shared-infrastructure.git
   - repo: https://github.com/hmcts/fpl-ccd-configuration.git
   - repo: https://github.com/hmcts/fpl-ccd-data-migration-tool.git


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
DFR-1997: decommission-notification-service
Notes:
* This service has been absorb by finrem-case-orchestration-service.
*
*
