### PR TITLE
Add Special Tribunals repos

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -220,4 +220,6 @@ prod:
   - repo: https://github.com/hmcts/family-api-gateway.git
   - repo: https://github.com/hmcts/et-sya-frontend.git
   - repo: https://github.com/hmcts/et-sya-api.git
+  - repo: https://github.com/hmcts/sptribs-case-api.git
+  - repo: https://github.com/hmcts/sptribs-shared-infrastructure.git
   - repo: https://github.com/hmcts/dtsse-shared-infrastructure.git


### PR DESCRIPTION
Notes:
Add Special Tribunals repos in scope of Release 1.0:
https://tools.hmcts.net/confluence/display/RSTR/Special+Tribunal+Release+1.0.0+Release+Dashboard

CR: CHG5011837