### PR TITLE
Allow azurerm_postgresql_flexible_server_configuration on dtsse

### DIFF
--- a/terraform-infra-approvals/dtsse-shared-infrastructure.json
+++ b/terraform-infra-approvals/dtsse-shared-infrastructure.json
@@ -3,7 +3,8 @@
     {"type": "azurerm_dashboard_grafana"},
     {"type": "azurerm_role_assignment"},
     {"type": "azurerm_postgresql_firewall_rule"},
-    {"type": "azurerm_key_vault_access_policy"}
+    {"type": "azurerm_key_vault_access_policy"},
+    {"type": "azurerm_postgresql_flexible_server_configuration"}
   ],
   "module_calls": []
 }


### PR DESCRIPTION
Need this extension for the dtsse postgres db that has the grafana data on it. Looks like it was manually added to the existing postgres db so I'd like to add it to tf for the flexi one