### PR TITLE
Update sscs-shared-infrastructure.json

### DIFF
--- a/terraform-infra-approvals/sscs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sscs-shared-infrastructure.json
@@ -8,6 +8,7 @@
       {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=sscs-remove-default-provider"},
       {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=sscs-remove-default-provider"},
       {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=fix/private-endpoint-provider"},
-      {"source":  "git@github.com:hmcts/terraform-module-log-analytics-workspace-id?ref=master"}
+      {"source":  "git@github.com:hmcts/terraform-module-log-analytics-workspace-id?ref=master"},
+      {"source":  "./modules/az_metric_alert"}
     ]
 }


### PR DESCRIPTION
Adding local module, as cnp-module-metric-alert only works for app insights queries, not log analytics.