### PR TITLE
Ardoq App Id for DTSSE

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -568,6 +568,8 @@ dtsse:
     build_notices_channel: "#reform-swe-builds"
   tags:
     application: core
+  ardoq:
+    application_id: "48f7e1661af3e8c64059f99f"
 civil:
   team: "Civil"
   namespace: "civil"


### PR DESCRIPTION
Adding the application_id used in Ardoq to allow for an integration from the pipeline to the Ardoq API.

This is a trial initially but will be rolled out to other teams in due course.