### PR TITLE
DTSPO-14461  Add option to specify gradle dependencies

### DIFF
--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -22,5 +22,5 @@ helm:
       date_deadline: "2023-03-29"
 gradle:
   java-logging:
-    - version: "6.0.5"
-      date_deadline: "2023-03-01"
+    - version: "6.0.1"
+      date_deadline: "2023-10-01"

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -20,3 +20,7 @@ helm:
   elasticsearch:
     - version: "7.17.3"
       date_deadline: "2023-03-29"
+gradle:
+  java-logging:
+    - version: "6.0.1"
+      date_deadline: "2023-10-01"

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -22,5 +22,5 @@ helm:
       date_deadline: "2023-03-29"
 gradle:
   java-logging:
-    - version: "6.0.1"
-      date_deadline: "2023-10-01"
+    - version: "6.0.5"
+      date_deadline: "2023-03-01"

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -23,4 +23,4 @@ helm:
 gradle:
   java-logging:
     - version: "6.0.1"
-      date_deadline: "2023-10-01"
+      date_deadline: "2023-10-28"


### PR DESCRIPTION
Will be used in conjunction with https://github.com/hmcts/cnp-jenkins-library/pull/1125 
to allow us to specify dependencies in build.gradle file to deprecate as well as helm charts that apps depend on.

