### PR TITLE
Add sdp-db-user module to wa-task-management whitelist

### DIFF
--- a/terraform-infra-approvals/wa-task-management-api.json
+++ b/terraform-infra-approvals/wa-task-management-api.json
@@ -4,5 +4,6 @@
       {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
       {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=jit-aat"},
       {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=RWA-2648-read-non-default-schema"}
+      {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"}
     ]
 }


### PR DESCRIPTION
Notes:
* We have a terraform module to add a SDP read user to a postgresql database.
* In the current requirement, the SDP user needs to be added to the wa-task-management database.
* https://github.com/hmcts/wa-task-management-api/pull/1152 has been raised for this, but the module needs to be whitelisted for use.
