### PR TITLE
Whitelist sdp db user module as global

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -53,6 +53,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
-    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"}
+    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"},
+    {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"}
   ]
 }

--- a/terraform-infra-approvals/wa-task-management-api.json
+++ b/terraform-infra-approvals/wa-task-management-api.json
@@ -3,7 +3,6 @@
     "module_calls": [
       {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
       {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=jit-aat"},
-      {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=RWA-2648-read-non-default-schema"},
-      {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"}
+      {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=RWA-2648-read-non-default-schema"}
     ]
 }


### PR DESCRIPTION
SDP module to create read users on the database is currently applied for wa-task-management-api but potentially should be re-used by all other teams with a database, so we want the module to be usable by all the other teams too.