### PR TITLE
Whitelist redis module branch

### DIFF
--- a/terraform-infra-approvals/xui-shared-infrastructure.json
+++ b/terraform-infra-approvals/xui-shared-infrastructure.json
@@ -1,6 +1,7 @@
 {
     "resources": [],
     "module_calls": [
-      {"source":  "git@github.com:hmcts/cnp-module-waf?ref=xui-waf-rules"}
+      {"source":  "git@github.com:hmcts/cnp-module-waf?ref=xui-waf-rules"},
+      {"source":  "git@github.com:hmcts/cnp-module-redis?ref=xui-webapp-temporary"}
     ]
 }  


### PR DESCRIPTION
This whitelists a branch of the cnp-redis-module which sets up a new private endpoint for redis. This is currently for test purposes only