### PR TITLE
Adds ardoq application_id for NFDIV

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -627,6 +627,8 @@ nfdiv:
     build_notices_channel: "#no-fault-divorce-builds"
   tags:
     application: no-fault-divorce
+  ardoq:
+    application_id: 5e008c29c8764747bd1f0da5
 ccd-elastic-search:
   team: "CCD"
   namespace:  "ccd"


### PR DESCRIPTION
Merging this PR will onboard NFDIV to Ardoq meaning the "Tech Stack" step will now send data to Ardoq. 

Currently this only affects the frontend app (tested here https://github.com/hmcts/nfdiv-frontend/pull/3270) but will also onboard the backend app once this https://github.com/hmcts/cnp-jenkins-library/pull/1162 is merged. 

Backend tested here: https://github.com/hmcts/nfdiv-case-api/pull/3257/