### PR TITLE
DTSRD-1205

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -53,6 +53,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
-    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"}
+    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"},
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-15347-add-subscription_rule"}
   ]
 }

--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -53,7 +53,6 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
-    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"},
-    {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-15347-add-subscription_rule"}
+    {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"}
   ]
 }

--- a/terraform-infra-approvals/rd-shared-infrastructure.json
+++ b/terraform-infra-approvals/rd-shared-infrastructure.json
@@ -1,6 +1,6 @@
 {
   "resources": [
-    {"type": "azurerm_role_assignment"}
+    {"type": "azurerm_pim_eligible_role_assignment"}
   ],
   "module_calls": [
   ]

--- a/terraform-infra-approvals/rd-shared-infrastructure.json
+++ b/terraform-infra-approvals/rd-shared-infrastructure.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {"type": "azurerm_role_assignment"}
+  ],
+  "module_calls": [
+  ]
+}


### PR DESCRIPTION
- Adding azurerm_role_assignment due to failing Jenkins build for rd-shared-infrastructure PR.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* There is a failing build for a PR on rd-shared-infrastructure - https://build.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Frd-shared-infrastructure/detail/PR-212/1/pipeline/
* This repo is using a terraform resource that is not allowed,
whitelists are stored in https://github.com/hmcts/cnp-jenkins-config/tree/master/terraform-infra-approvals
send a pull request if you think this is in error.
non whitelisted resources:
```
[{managed azurerm_pim_eligible_role_assignment this {azurerm } {storage-account-rd-data-extracts.tf 79}}]