### PR TITLE
DTSPO-15800:Add angular version

### DIFF
--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -30,3 +30,7 @@ gradle:
   java-logging:
     - version: "6.0.1"
       date_deadline: "2023-10-28"
+npm:
+  @angular/core:
+    - version: "15"
+      date_deadline: "2023-10-28" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -33,4 +33,4 @@ gradle:
 npm:
   angular/core:
     - version: "16"
-      date_deadline: "2023-02-29" 
+      date_deadline: "2023-04-29" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -32,5 +32,5 @@ gradle:
       date_deadline: "2023-10-28"
 npm:
   angular/core:
-    - version: "16"
+    - version: "15"
       date_deadline: "2023-10-28" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -32,5 +32,5 @@ gradle:
       date_deadline: "2023-10-28"
 npm:
   angular/core:
-    - version: "16"
-      date_deadline: "2023-04-29" 
+    - version: "15"
+      date_deadline: "2024-03-25" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -31,6 +31,6 @@ gradle:
     - version: "6.0.1"
       date_deadline: "2023-10-28"
 npm:
-  @angular/core:
+  angular/core:
     - version: "15"
       date_deadline: "2023-10-28" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -32,5 +32,5 @@ gradle:
       date_deadline: "2023-10-28"
 npm:
   angular/core:
-    - version: "15"
-      date_deadline: "2023-10-28" 
+    - version: "16"
+      date_deadline: "2024-02-29" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -32,5 +32,5 @@ gradle:
       date_deadline: "2023-10-28"
 npm:
   angular/core:
-    - version: "15"
+    - version: "16"
       date_deadline: "2023-10-28" 

--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -33,4 +33,4 @@ gradle:
 npm:
   angular/core:
     - version: "16"
-      date_deadline: "2024-02-29" 
+      date_deadline: "2023-02-29" 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15800

Adds angular/core version to deprecation map, and by extension enables us to track other npm dependencies in the future too

In junction with https://github.com/hmcts/cnp-jenkins-library/pull/1207/files

Uses some generic date for now until we have a need to deprecate some version of Angular

2nd part of this will go in in another PR, which is to update the angular major version based on support in an automated way