### PR TITLE
Remove ecm-consumer file as no longer required

### DIFF
--- a/terraform-infra-approvals/ecm-consumer.json
+++ b/terraform-infra-approvals/ecm-consumer.json
@@ -1,6 +1,0 @@
-{
-    "resources": [],
-    "module_calls": [
-      {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-16806-schema-owner"}
-    ]
-  }


### PR DESCRIPTION
Notes:
* Added for testing pr branch on terraform-module-postgres-flexible
* https://github.com/hmcts/terraform-module-postgresql-flexible/pull/58 
* No longer required as team have completed migration
