### PR TITLE
Testing storage auto growth in ccd

### DIFF
--- a/terraform-infra-approvals/ccd-data-store-api.json
+++ b/terraform-infra-approvals/ccd-data-store-api.json
@@ -1,0 +1,6 @@
+{
+    "resources": [],
+    "module_calls": [
+      {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=add-auto-grow-option"}
+    ]
+}


### PR DESCRIPTION
Notes:
* Added for testing storage auto growth for postgres flexible server on ccd-data-store-api
* In relation to https://tools.hmcts.net/jira/browse/DTSPO-16954
