### PR TITLE
Pointing app to postgres flexible test branch

### DIFF
--- a/terraform-infra-approvals/rd-caseworker-ref-api.json
+++ b/terraform-infra-approvals/rd-caseworker-ref-api.json
@@ -1,0 +1,6 @@
+{
+    "resources": [],
+    "module_calls": [
+      {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-16806-schema-owner"}
+    ]
+}


### PR DESCRIPTION
Notes:
* Pointing rd-caseworker-ref-api to test branch in terraform-module-postgresql-flexible.
* Will be using this branch to test this change https://github.com/hmcts/terraform-module-postgresql-flexible/pull/58
*
