### PR TITLE
Allow temp module call for camunda-bpm

### DIFF
--- a/terraform-infra-approvals/camunda-bpm.json
+++ b/terraform-infra-approvals/camunda-bpm.json
@@ -1,0 +1,6 @@
+{
+    "resources": [],
+    "module_calls": [
+      {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=temp-disable-ha-camunda"}
+    ]
+}


### PR DESCRIPTION
Notes:
* Allowing module call to temp postgresql branch for camunda-bpm
* Related to work on https://tools.hmcts.net/jira/browse/DTSPO-17274

