### PR TITLE
Move time to enable us to fix ccd chart issues

### DIFF
--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -1,10 +1,10 @@
 helm:
   java:
     - version: "5.2.0"
-      date_deadline: "2024-04-30"
+      date_deadline: "2024-05-23"
   nodejs:
     - version: "3.1.0"
-      date_deadline: "2024-04-30"
+      date_deadline: "2024-05-23"
   job:
     - version: "2.1.1"
       date_deadline: "2024-01-24"
@@ -13,7 +13,7 @@ helm:
       date_deadline: "2023-10-23"
   base:
     - version: "1.3.0"
-      date_deadline: "2024-04-30"
+      date_deadline: "2024-05-23"
   blobstorage:
     - version: "1.0.1"
       date_deadline: "2023-08-13"


### PR DESCRIPTION

Related to DTSPO-17525, on upgrading eg. chart-java, teams that also use chart-ccd have errors coming from charts within chart-ccd.
Move java/node/base dates out to enable us to investigate ccd-chart issue and give teams time to get changes in if necessary.