### PR TITLE
Temp add https version for ccd-elastic-search

### DIFF
--- a/terraform-infra-approvals/ccd-elastic-search.json
+++ b/terraform-infra-approvals/ccd-elastic-search.json
@@ -7,6 +7,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=curator"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=ES-7x-Upgrade"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=RDM-13038"},
+    {"source":  "https://github.com/hmcts/cnp-module-elk.git?ref=RDM-13038"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=Ethosldata"},
     {"source":  "git@github.com:hmcts/cnp-module-logstash.git?ref=master"}


### PR DESCRIPTION
SSH isn't working because the module is private. Switching to https to unblock temporarily whilst I figure out the issue in the backgroun