### PR TITLE
Revert "Temp add https version for ccd-elastic-search"

### DIFF
--- a/terraform-infra-approvals/ccd-elastic-search.json
+++ b/terraform-infra-approvals/ccd-elastic-search.json
@@ -7,7 +7,6 @@
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=curator"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=ES-7x-Upgrade"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=RDM-13038"},
-    {"source":  "https://github.com/hmcts/cnp-module-elk.git?ref=RDM-13038"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-elk.git?ref=Ethosldata"},
     {"source":  "git@github.com:hmcts/cnp-module-logstash.git?ref=master"}


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-config#1067

Didn't solve it. Issue was more related to the fact jenkins is not set up to use modules that are private in github