### PR TITLE
Extend for ccd-chart issues

### DIFF
--- a/deprecation-config.yml
+++ b/deprecation-config.yml
@@ -1,10 +1,10 @@
 helm:
   java:
     - version: "5.2.0"
-      date_deadline: "2024-05-23"
+      date_deadline: "2024-06-12"
   nodejs:
     - version: "3.1.0"
-      date_deadline: "2024-05-23"
+      date_deadline: "2024-06-12"
   job:
     - version: "2.1.1"
       date_deadline: "2024-01-24"
@@ -13,7 +13,7 @@ helm:
       date_deadline: "2023-10-23"
   base:
     - version: "1.3.0"
-      date_deadline: "2024-05-23"
+      date_deadline: "2024-06-12"
   blobstorage:
     - version: "1.0.1"
       date_deadline: "2023-08-13"


### PR DESCRIPTION
Updated most dependencies in chart-ccd and created a new release, but there was one error remaining because that dependency had no new version and ccd will need to look into getting that up to date. Testing a new fix from chart perspective today but need to give teams more time to take this into account.
