### PR TITLE
whitelist the branch DTSPO-17844 of terraform-module-postgresql-flexible

### DIFF
--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -5,6 +5,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=postgresql_tf_changes"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=public-flexibleserver"},
-    {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"}
+    {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"}
   ]
 }


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

the ticket DTSPO-17844  

Notes:
* As of AzureRM Provider 3.105.0 the property public_network_access_enabled needs to be set explicitly
