### PR TITLE
Add common tags module to whitelist

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -55,6 +55,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"},
     {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"},
+    {"source":  "git@github.com:hmcts/terraform-module-common-tags.git?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=fix-count"}
   ]
 }


### PR DESCRIPTION
Notes:
* Add terraform-module-common-tags to global whitelist
* Pipeline currently failing due to this
