### PR TITLE
Add docmosis-infrastructure repo to allow list for prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -235,3 +235,4 @@ prod:
   - repo: https://github.com/hmcts/tax-tribunals-datacapture.git
   - repo: https://github.com/hmcts/help-with-fees-shared-infrastructure.git
   - repo: https://github.com/hmcts/et-pet-shared-infrastructure.git
+  - repo: https://github.com/hmcts/docmosis-infrastructure.git


### PR DESCRIPTION
Notes:
* Adding new docmosis-infrastructure repo to allow list for prod environment
* https://github.com/hmcts/docmosis-infrastructure
