### PR TITLE
Update channel id docmosis

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -163,7 +163,7 @@ docmosis:
   azure_ad_group: "DTS Platform Operations"
   slack:
     contact_channel: "#platops-help"
-    channel_id: "C8SR5CAMU"
+    channel_id: "G01E6GKRKAM"
     build_notices_channel: "#platops-build-notices"
   tags:
     application: docmosis

--- a/team-config.yml
+++ b/team-config.yml
@@ -163,7 +163,7 @@ docmosis:
   azure_ad_group: "DTS Platform Operations"
   slack:
     contact_channel: "#platops-help"
-    channel_id: "G01E6GKRKAM"
+    channel_id: "C01HP1ZL4R5"
     build_notices_channel: "#platops-build-notices"
   tags:
     application: docmosis


### PR DESCRIPTION
Notes:
* Changes docmosis channel id to #platops-build-notices channel to receive alerts
* Previously was #platops-help channel but would not have permissions to write here
