### PR TITLE
Globally approve 4.x branch for storage account

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -33,7 +33,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-key-vault?ref=azurermv2"},
     {"source":  "git@github.com:hmcts/cnp-module-shutterpage?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=master"},
-    {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=azurermv2"},
+    {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"},
     {"source":  "git@github.com:hmcts/cnp-module-storage?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-webapp?ref=master"},


### PR DESCRIPTION
Also removes approval for `cnp-module-storage-account` branch `azurermv2` as a search found no one uses it any more.