### PR TITLE
Update global.json

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -22,6 +22,7 @@
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"},
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-18682"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=main"},


### PR DESCRIPTION
We are currently upgrading the tf versioning to 4 and need to test some repos against these branches before merging to master.
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/4.0-upgrade-guide
PR in reference: https://github.com/hmcts/terraform-module-servicebus-subscription/pull/26
Failing pipeline for testing: https://build.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-service/detail/PR-5330/2/pipeline/