### PR TITLE
app insights 4.x branch

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -26,6 +26,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=main"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-18682"},
+    {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=4.x"},
     {"source":  "git@github.com:hmcts/cnp-module-api-mgmt?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-api-mgmt-product?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-api-mgmt-api?ref=master"},


### PR DESCRIPTION
Needed to add location for app insights alert (but any version more than 6 months old doesn't have it so put into a separate branch)

Notes:
*
*
*
