### PR TITLE
LAU-948 adding random_password to whitelist

### DIFF
--- a/terraform-infra-approvals/lau-case-backend.json
+++ b/terraform-infra-approvals/lau-case-backend.json
@@ -1,0 +1,5 @@
+{
+  "resources": [
+    {"type": "random_password"}
+  ]
+}


### PR DESCRIPTION
Adding random_password to whitelist for lau-case-backend repo

PR Created in lau-case-backend for generating  random_password for encryption key

https://github.com/hmcts/lau-case-backend/pull/756
