### PR TITLE
Moving Hearings Infra to shared infra repo

### DIFF
--- a/terraform-infra-approvals/sscs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sscs-shared-infrastructure.json
@@ -1,7 +1,8 @@
 {
     "resources": [
       {"type": "azapi_resource"},
-      {"type": "azurerm_monitor_diagnostic_setting"}
+      {"type": "azurerm_monitor_diagnostic_setting"},
+      {"type": "azurerm_servicebus_subscription_rule"}
     ],
     "module_calls": [
       {"source":  "git@github.com:hmcts/cnp-module-action-group?ref=SSCS-10638-output_id"},


### PR DESCRIPTION
Copied from https://github.com/hmcts/cnp-jenkins-config/blob/master/terraform-infra-approvals/sscs-hearings-api.json#L3 as the repo is getting deprecated. 

https://tools.hmcts.net/jira/browse/SSCSSI-416 