### PR TITLE
whitelist the 4.x branch of cnp-module-redis

### DIFF
--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -6,6 +6,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=public-flexibleserver"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"},
+    {"source":  "git@github.com:hmcts/cnp-module-redis?ref=4.x"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"}
   ]
 }


### PR DESCRIPTION

This is required to test the new 4.x branch created for the repo `cnp-module-redis`, as a part of solution implemented for DTSPO-22371

