### PR TITLE
Adding recipes team config to allow Jenkins builds

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -918,3 +918,13 @@ pcs:
     build_notices_channel: "#pcs-tech"
   tags:
     application: "possession-claim-service"
+recipes:
+  team: "CNP"
+  namespace: "cnp"
+  azure_ad_group: "DTS Platform Operations"
+  slack:
+    contact_channel: "#platops-help"
+    channel_id: "C05KAG00K1N"
+    build_notices_channel: "#platops-build-notices"
+  tags:
+    application: core


### PR DESCRIPTION
Adding a new team config block for Recipes services to allow builds via cnp Jenkins
