### PR TITLE
CME-309: Whitelist cnp-module-redis 4.x branch

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -44,6 +44,7 @@
     {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=4.x"},
     {"source":  "git@github.com:hmcts/cnp-module-storage?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=master"},
+    {"source":  "git@github.com:hmcts/cnp-module-redis?ref=4.x"},
     {"source":  "git@github.com:hmcts/cnp-module-webapp?ref=master"},
     {"source":  "git@github.com:hmcts/cnp-module-webapp?ref=revert-159-tf-0.12.x"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=master"},


### PR DESCRIPTION
Notes:
* Whitelist cnp-module-redis 4.x branch for https://github.com/hmcts/ccd-case-activity-api/pull/451
*
*
