### PR TITLE
SSCSCI-1542 Whitelist private-endpoint-provider-4.x branch for SSCS

### DIFF
--- a/terraform-infra-approvals/sscs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sscs-shared-infrastructure.json
@@ -9,6 +9,7 @@
       {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=sscs-remove-default-provider"},
       {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=sscs-remove-default-provider"},
       {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=fix/private-endpoint-provider"},
+      {"source":  "git@github.com:hmcts/cnp-module-storage-account?ref=fix/private-endpoint-provider-4.x"},
       {"source":  "git@github.com:hmcts/terraform-module-log-analytics-workspace-id?ref=master"},
       {"source":  "./modules/az_metric_alert?ref=master"},
       {"source":  "./modules/az_metric_alert?ref=rhodrif"},


### PR DESCRIPTION
Whitelist cnp-module-storage-account?ref=fix/private-endpoint-provider-4.x for SSCS. Needed to update azurerm to 4.x