### PR TITLE
Add https version of cnp-module-metric-alert as it's erroring on pipeline

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -67,6 +67,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=fix-count"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=CME-120"},
-    {"source":  "git@github.com:hmcts/terraform-module-vm-bootstrap?ref=master"}
+    {"source":  "git@github.com:hmcts/terraform-module-vm-bootstrap?ref=master"},
+    {"source":  "git::https://github.com/hmcts/cnp-module-metric-alert.git"}
   ]
 }


### PR DESCRIPTION
<img width="1820" alt="image" src="https://github.com/user-attachments/assets/0bcad98f-c071-4d41-9188-1d4630af3224" />
Getting the following error when I try to use cnp-module-metric-alert.

Before I changed from the https version, I was getting this error:
<img width="466" alt="image" src="https://github.com/user-attachments/assets/0c8c35ae-3385-45b7-ab58-4fae59a5f780" />

@Tyler-35 