### PR TITLE
Adding allowed module branches for civil-service

### DIFF
--- a/terraform-infra-approvals/civil-service.json
+++ b/terraform-infra-approvals/civil-service.json
@@ -1,8 +1,12 @@
 {
-  "resources": [
-    {"type": "azurerm_servicebus_subscription_rule"},
-    {"type": "azurerm_function_app"},
-    {"type": "azurerm_app_service_plan"},
-    {"type": "azurerm_linux_function_app"}
-  ]
+	"resources": [
+		{ "type": "azurerm_servicebus_subscription_rule" },
+		{ "type": "azurerm_function_app" },
+		{ "type": "azurerm_app_service_plan" },
+		{ "type": "azurerm_linux_function_app" }
+	],
+	"module_calls": [
+		{ "source": "git@github.com:hmcts/terraform-module-azurerm_servicebus_subscription?ref=DTSPO-25025-add-status-flag" },
+    { "source": "git@github.com:hmcts/terraform-module-azurerm_servicebus_subscription?ref=4.x" }
+	]
 }


### PR DESCRIPTION
Notes:
* Allowing two branches of `terraform-module-servicebus-subscription` module
* One is for testing a change and the other is the branch they will move to once change tested and confirmed working

