### PR TITLE
Update team-config.yml

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -643,16 +643,6 @@ civil:
     build_notices_channel: "#civil_notifications"
   tags:
     application: civil
-civil-citizen-ui:
-  team: "civil"
-  namespace: "civil"
-  azure_ad_group: DTS Civil
-  slack:
-    contact_channel: "#civil_contact"
-    channel_id: "C020H1XLM9S"
-    build_notices_channel: "#civil_notifications"
-  tags:
-    application: civil-citizen-ui
 hmi:
   team: "Future hearings - HMI"
   namespace: "hmi"


### PR DESCRIPTION

Notes:
We only created this team config as a PoC. Now that we can apply this to all of Civil, we don't need the separate team for civil-citizen-ui.
