### PR TITLE
DTSPO-25133: Adding module testing branch to plum-recipes whitelist

### DIFF
--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -8,6 +8,6 @@
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=4.x"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"},
-    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-25133-testing-postgres-module-change"}
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-25133-configuring-database-groups"}
   ]
 }

--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -7,6 +7,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=public-flexibleserver"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=4.x"},
-    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"}
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-25133-testing-postgres-module-change"}
   ]
 }


### PR DESCRIPTION
Resolves [1149](https://github.com/hmcts/cnp-plum-recipes-service/pull/1149)

Notes:
* Adding postgres module testing branch to cnp-plum-recipes-service whitelist to allow PR checks to pass
