### PR TITLE
PAY-7820: Enable CFT API logging for ccpay-payment-app

### DIFF
--- a/terraform-infra-approvals/ccpay-payment-app.json
+++ b/terraform-infra-approvals/ccpay-payment-app.json
@@ -1,7 +1,7 @@
 {
   "resources": [
-    {"type": "azurerm_template_deployment"}
+    {"type": "azurerm_template_deployment"},
+    {"type": "azurerm_api_management_api_diagnostic"}
   ],
   "module_calls": []
 }
-


### PR DESCRIPTION
Resolves https://tools.hmcts.net/jira/browse/PAY-7820

Notes:
* Payment Failure requests from Liberata are not coming through. 
* Need the CFT API logging on this component to diagnose issues.
*
