### PR TITLE
DTSPO-26253 - Allow testing of module branch

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -25,6 +25,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-queue?ref=4.x"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"},
+    {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-26253/use-namespace-id"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-18682"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-servicebus-topic?ref=4.x"},


### PR DESCRIPTION
Module branch is attempting to resolve issue with namespace_name not being an expected value in the data resource for service bus subscriptions