### PR TITLE
FPVTL-907: Enable family-api-gateway to use apim logging

### DIFF
--- a/terraform-infra-approvals/family-api-gateway.json
+++ b/terraform-infra-approvals/family-api-gateway.json
@@ -1,0 +1,6 @@
+{
+  "resources": [
+    {"type": "azurerm_api_management_api_diagnostic"}
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
Need to add logging to our apim endpoints to log external requests through APIM, but our pipeline is being blocked as we aren't allowed to add this terraform resource - this is the same approach blob router/etc. did to add their logging to APIM in similar files.

(https://github.com/hmcts/cnp-jenkins-config/blob/master/terraform-infra-approvals/blob-router-service.json)