### PR TITLE
Plum: allow 4.x upgrade azurerm

### DIFF
--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -6,6 +6,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=public-flexibleserver"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency"},
+    {"source": "git@github.com:hmcts/cnp-module-redis?ref=DTSPO-17012-data-persistency-4.x"},
     {"source":  "git@github.com:hmcts/cnp-module-redis?ref=4.x"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-25133-configuring-database-groups"}


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
Redis persistence work is being picked up again soon, but need to allow azurerm upgrade to 4.x to prevent breaking build

Notes:
*
*
*
