### PR TITLE
Whitelist azurerm_servicebus_topic_authorization_rule for sptribs-share-infra

### DIFF
--- a/terraform-infra-approvals/sptribs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sptribs-shared-infrastructure.json
@@ -1,0 +1,5 @@
+{
+  "resources": [
+    {"type": "azurerm_servicebus_topic_authorization_rule"}
+  ]
+}


### PR DESCRIPTION
Notes:
* This is to allow sptribs to be able to create a sendonly key on ccd-case-events topic to help decentralising CCD data.
* Original PR on sptribs  https://github.com/hmcts/sptribs-shared-infrastructure/pull/47
* Issue described in https://tools.hmcts.net/jira/browse/DTSPO-27289 

