### PR TITLE
DTSPO-30177: migrate camunda registry from hmctsprivate to hmctsprod

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -570,7 +570,7 @@ data-generator:
 camunda:
   team: "Software Engineering"
   namespace: "camunda"
-  registry: "hmctsprivate"
+  registry: "hmctsprod"
   azure_ad_group: "DTS Platform Operations"
   slack:
     contact_channel: "#platops-help"


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
https://tools.hmcts.net/jira/browse/DTSPO-30177
Notes:
*Migrate camunda registry from hmctsprivate to hmctsprod
*
*
