### PR TITLE
Revert "Allow new branch for idam-shared-infrastructure"

### DIFF
--- a/terraform-infra-approvals/idam-shared-infrastructure.json
+++ b/terraform-infra-approvals/idam-shared-infrastructure.json
@@ -4,7 +4,6 @@
   ],
   "module_calls": [
     {"source": "git@github.com:hmcts/cnp-module-waf?ref=SIDM-2128_add_idam_waf_exclusions"},
-    {"source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=fix%2Fremove-namespace_name"},
-    {"source": "git@github.com:hmcts/terraform-module-application-insights?ref=endakelly-patch-1"}
+    {"source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=fix%2Fremove-namespace_name"}
   ]
 }


### PR DESCRIPTION
Reverts hmcts/cnp-jenkins-config#1214

No longer needed