### PR TITLE
chore: add git pull --rebase before push to handle concurrent commits

### DIFF
--- a/.github/workflows/remove-archived-repos.yml
+++ b/.github/workflows/remove-archived-repos.yml
@@ -64,6 +64,7 @@ jobs:
             git config user.email github-platform-operations@hmcts.net
             git add deployment-controls.yml
             git commit -m "chore: remove archived repos from deployment-controls.yml"
+            git pull --rebase
             git push
           else
             echo "No archived repos to remove - skipping commit"


### PR DESCRIPTION


Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
https://tools.hmcts.net/jira/browse/DTSPO-32080
Notes:
* This ensures the workflow rebases its local commit on top of any recent changes to master, preventing non-fast-forward push errors when multiple commits are made to master concurrently.
*
*
