### PR TITLE
chore: use git push --force-with-lease for safe concurrent pushes

### DIFF
--- a/.github/workflows/remove-archived-repos.yml
+++ b/.github/workflows/remove-archived-repos.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Commit to master
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        continue-on-error: true
         run: |
           if [ "$REMOVED" -gt 0 ]; then
             git config user.name hmcts-platform-operations

--- a/.github/workflows/remove-archived-repos.yml
+++ b/.github/workflows/remove-archived-repos.yml
@@ -65,7 +65,7 @@ jobs:
             git add deployment-controls.yml
             git commit -m "chore: remove archived repos from deployment-controls.yml"
             git pull --rebase
-            git push
+            git push --force-with-lease
           else
             echo "No archived repos to remove - skipping commit"
           fi


### PR DESCRIPTION

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)
https://tools.hmcts.net/jira/browse/DTSPO-32080

Notes:
* use git push --force-with-lease for safe concurrent pushes
*
*
