### PR TITLE
Adding new Redis Module for Jenkins approval

### DIFF
--- a/terraform-infra-approvals/cnp-plum-recipes-service.json
+++ b/terraform-infra-approvals/cnp-plum-recipes-service.json
@@ -11,6 +11,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-17844-publicNetworkAccessConflicts"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=dtspo-25133-configuring-database-groups"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=backup-vault-update"},
-    {"source":  "git@github.com:hmcts/cnp-module-app-service-plan?ref=DTSPO-30614-modernise-app-service-plan-module"}
+    {"source":  "git@github.com:hmcts/cnp-module-app-service-plan?ref=DTSPO-30614-modernise-app-service-plan-module"},
+    {"source":  "git@github.com:hmcts/terraform-module-azure-managed-redis?ref=main"}
   ]
 }


### PR DESCRIPTION
Adds `terraform-module-azure-managed-redis?ref=main` to the
plum-recipes-service approvals list so the sandbox trial of the new
module can run through the CNP Jenkins pipeline.

https://tools.hmcts.net/jira/browse/DTSPO-32017
