### PR TITLE
Add XUI Jenkins agent mapping

### DIFF
--- a/team-config.yml
+++ b/team-config.yml
@@ -403,6 +403,7 @@ xui:
   team: "Expert UI"
   namespace: "xui"
   azure_ad_group: dcd_group_expertui_v2
+  agent: "xui"
   slack:
     contact_channel: "#xui-pipeline"
     channel_id: "CHW1CDDM0"


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A - PlatOps requested XUI 8CPU Jenkins agent enablement test.

### Repository being enabled for deployment ###

https://github.com/hmcts/rpx-xui-webapp
https://github.com/hmcts/rpx-xui-e2e-tests

### Change description ###

Adds `agent: "xui"` to the existing Expert UI team config so Jenkins shared library calls using product `xui` can resolve to the XUI Jenkins VM agent label.

This is part of the staged XUI 8CPU Jenkins agent test. The matching VM template already exists in `cnp-flux-config` as `cnp-jenkins-ubuntu-xui` with label `xui`.

Validation:
- `git diff --check -- team-config.yml`
- `ruby -e "require 'psych'; Psych.load_file('team-config.yml')"`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
