### PR TITLE
DIAC-2486  exposing IAC home office api through api Management

### DIFF
--- a/terraform-infra-approvals/ia-home-office-integration-api.json
+++ b/terraform-infra-approvals/ia-home-office-integration-api.json
@@ -1,0 +1,6 @@
+{
+  "resources": [    
+    {"type": "azurerm_api_management_api_diagnostic"}   
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
DIAC-2486  exposing IAC home office api through api Management

Below terraform changes to enable app insights for the new APIM is failing due to white listing requirement.
https://github.com/hmcts/ia-home-office-integration-api/pull/479

