### PR TITLE
DTSPO-31965: approve temporary key vault module branch

### DIFF
--- a/terraform-infra-approvals/civil-service.json
+++ b/terraform-infra-approvals/civil-service.json
@@ -7,6 +7,7 @@
 	],
 	"module_calls": [
 		{ "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-25025-add-status-flag" },
-    { "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x" }
+    { "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x" },
+    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access" }
 	]
 }

--- a/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
+++ b/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
@@ -1,0 +1,9 @@
+{
+  "resources": [
+    {"type": "azurerm_role_assignment"},
+    {"type": "azurerm_servicebus_queue"}
+  ],
+  "module_calls": [
+    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"}
+  ]
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-30108

Adds repo-specific Terraform infra approvals for the temporary `cnp-module-key-vault` branch used during the Jenkins environment managed identity rollout.
