### PR TITLE
DTSPO-31965: remove misplaced Toffee approval

### DIFF
--- a/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
+++ b/terraform-infra-approvals/sds-toffee-shared-infrastructure.json
@@ -1,9 +1,0 @@
-{
-  "resources": [
-    {"type": "azurerm_role_assignment"},
-    {"type": "azurerm_servicebus_queue"}
-  ],
-  "module_calls": [
-    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"}
-  ]
-}


### PR DESCRIPTION
Remove the Toffee approval from cnp-jenkins-config because Toffee uses sds-jenkins-config.