### PR TITLE
DTSPO-31965: approve civil key vault module branch

### DIFF
--- a/terraform-infra-approvals/civil-service.json
+++ b/terraform-infra-approvals/civil-service.json
@@ -8,6 +8,7 @@
 	"module_calls": [
 		{ "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-25025-add-status-flag" },
     { "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x" },
-    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access" }
+    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access" },
+    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access-da" }
 	]
 }


### PR DESCRIPTION
Approves the temporary cnp-module-key-vault branch used by the civil-service Jenkins agent migration PR.