### PR TITLE
DTSPO-31965: approve preview AAT key vault module refs

### DIFF
--- a/terraform-infra-approvals/cmc-shared-infrastructure.json
+++ b/terraform-infra-approvals/cmc-shared-infrastructure.json
@@ -1,6 +1,7 @@
 {
   "resources": [],
   "module_calls": [
-    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=cmc-in-prevention-mode"}
+    {"source":  "git@github.com:hmcts/cnp-module-waf?ref=cmc-in-prevention-mode"},
+    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access-da"}
   ]
 }

--- a/terraform-infra-approvals/send-letter-service.json
+++ b/terraform-infra-approvals/send-letter-service.json
@@ -1,7 +1,7 @@
 {
   "resources": [],
   "module_calls": [
-    {"source":  "git@github.com:hmcts/cnp-module-storage-account.git?ref=mi-role-assignments"}
+    {"source":  "git@github.com:hmcts/cnp-module-storage-account.git?ref=mi-role-assignments"},
+    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access-da"}
   ]
 }
-


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Adds Terraform infra approvals for the temporary key vault module branch used by send-letter-service and cmc-shared-infrastructure.
