### PR TITLE
DTSPO-31965: approve RPX preview key vault access policy

### DIFF
--- a/terraform-infra-approvals/rpx-xui-webapp.json
+++ b/terraform-infra-approvals/rpx-xui-webapp.json
@@ -17,7 +17,8 @@
     {"type": "azurerm_automation_runbook"},
     {"type": "azurerm_email_communication_service"},
     {"type": "azurerm_email_communication_service_domain"},
-    {"type": "azurerm_communication_service_email_domain_association"}
+    {"type": "azurerm_communication_service_email_domain_association"},
+    {"type": "azurerm_key_vault_access_policy"}
   ],
   "module_calls": [
     {"source": "git@github.com:hmcts/cnp-module-waf?ref=xui-waf-rules"},


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
* Adds Terraform infra approval for RPX to create azurerm_key_vault_access_policy.
