### PR TITLE
chore: update jenkins allow list before roll-out

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -403,6 +403,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/ia-ccd-migration-tool.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/ia-citizen-ui-e2e.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/ia-e2etests.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/ia-hearings-api.git
@@ -454,6 +456,8 @@ repositories:
   - repo: https://github.com/hmcts/labs-hub-ngfw-poc.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/labs-hurricanepilot.git
+    deployment-enabled: true
+  - repo: https://github.com/hmcts/labs-Ibrahimelsanosi-moj.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/labs-marketplace-api.git
     deployment-enabled: true


### PR DESCRIPTION
## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)
[DTSPO-30147](https://tools.hmcts.net/jira/browse/DTSPO-30147)

### Change description
- Final pass on current repositories before rolling out deployment controls