### PR TITLE
Add cnp-jenkins-library

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -145,6 +145,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/cnp-idam-vault.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/cnp-jenkins-library.git
+    deployment-enabled: false
   - repo: https://github.com/hmcts/cnp-keda-shared-infrastucture.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/cnp-module-adf.git


### PR DESCRIPTION
## 🔧 Regular change

Pipeline is disabled now in sandbox jenkins, testing if this is the reason

## 🚀 New repository / enabling deployments

Adding cnp-jenkins-library

### Repository being enabled for deployment

Deployment not enabled

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [x] Repository has branch protection rules enabled
- [x] Pull requests require at least 1 approval before merging
- [x] Status checks are required to pass before merging
- [] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
