### PR TITLE
fix: update jenkinsfile to use allowed steps

### DIFF
--- a/jobdsl/Jenkinsfile_seed
+++ b/jobdsl/Jenkinsfile_seed
@@ -1,5 +1,12 @@
 node {
-  jobDsl scriptText: new URL('https://raw.githubusercontent.com/hmcts/cnp-jenkins-config/master/jobdsl/organisations-beta.groovy').text,
+  checkout([$class: 'GitSCM',
+    branches: [[name: 'master']],
+    userRemoteConfigs: [[
+      url: 'https://github.com/hmcts/cnp-jenkins-config.git',
+      credentialsId: 'hmcts-jenkins-cnp'
+    ]]
+  ])
+  jobDsl targets: 'jobdsl/organisations-beta.groovy',
          removedJobAction: 'IGNORE',
          removedViewAction: 'IGNORE'
 }


### PR DESCRIPTION
## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)

### Change description
- Update seed job to use allowed pipeline steps
- `.text` is disallowed as a security risk so opting for a git checkout instead