### PR TITLE
fix: update jenkinsfile with workaround for invalid job name

### DIFF
--- a/jobdsl/Jenkinsfile_seed
+++ b/jobdsl/Jenkinsfile_seed
@@ -6,7 +6,7 @@ node {
       credentialsId: 'hmcts-jenkins-cnp'
     ]]
   ])
-  jobDsl targets: 'jobdsl/organisations-beta.groovy',
+  jobDsl scriptText: readFile('jobdsl/organisations-beta.groovy'),
          removedJobAction: 'IGNORE',
          removedViewAction: 'IGNORE'
 }


### PR DESCRIPTION
## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)

### Change description
- Workaround for invalid dsl job name
- Pipeline fails currently with following error:
```
invalid script name 'organisations-beta.groovy; script names may only contain letters, digits and underscores, but may not start with a digit
```