### PR TITLE
[NFDIV-5620] Unarchive nfdiv shared infrastructure

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -489,6 +489,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/nfdiv-performance.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/nfdiv-shared-infrastructure.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/pcq-backend.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/pcq-consolidation-service.git


### PR DESCRIPTION
We are unarchiving the nfdiv-shared-infrastructure repo after it was automatically archived by a platops job that detects stale repositories.

## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)

### Change description

---

## 🚀 New repository / enabling deployments

> Complete this section **only** when adding a repository to `deployment-controls.yml`. Remove if not applicable.

### Repository being enabled for deployment

<!-- Link to the repository e.g. https://github.com/hmcts/my-service -->

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [ ] Repository has branch protection rules enabled
- [ ] Pull requests require at least 1 approval before merging
- [ ] Status checks are required to pass before merging
- [ ] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
