### PR TITLE
DTSCCI-5490 Whitelist Azure Managed Redis for civil-service

### DIFF
--- a/terraform-infra-approvals/civil-service.json
+++ b/terraform-infra-approvals/civil-service.json
@@ -9,6 +9,7 @@
 		{ "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-25025-add-status-flag" },
     { "source": "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x" },
     { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access" },
-    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access-da" }
-	]
+    { "source": "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access-da" },
+	{"source": "git@github.com:hmcts/terraform-module-azure-managed-redis?ref=main"}	
+]
 }


### PR DESCRIPTION

## 🔧 Regular change

### JIRA link (if applicable)
DTSCCI-5490 

### Change description
Whitelist Azure Managed Redis for civil-service

### Repository being enabled for

https://github.com/hmcts/civil-service

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [x] Repository has branch protection rules enabled
- [x] Pull requests require at least 1 approval before merging
- [x] Status checks are required to pass before merging
- [x] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
