### PR TITLE
Add postgres-flexible-server DTSPO-30107 branch to global.json

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -65,6 +65,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=adding-postgresql-ad-administrator"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=postgres-vnet-provider"},
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=DTSPO-30107-additional-postgres-admins"},
     {"source":  "git@github.com:hmcts/cnp-module-postgres?ref=redundant-backup-optional"},
     {"source":  "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"},
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=fix-count"},


### PR DESCRIPTION
## 🔧 Regular change

Added terraform-module-postgresql-flexible DTSPO-30107-additional-postgres-admins branch.  This is needed to enable jenkins migration for teams.

### Change description

Added terraform-module-postgresql-flexible DTSPO-30107-additional-postgres-admins branch.  This is needed to enable jenkins migration for teams.

---

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [x] Repository has branch protection rules enabled
- [x] Pull requests require at least 1 approval before merging
- [x] Status checks are required to pass before merging
- [x] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
