### PR TITLE
EXUI-4915 Add rpx-xui-media-viewer to Jenkins controls

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -627,6 +627,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-manage-organisations.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/rpx-xui-media-viewer.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-webapp.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/send-letter-service.git


### PR DESCRIPTION
## Summary
- add hmcts/rpx-xui-media-viewer to deployment controls

## Context
Companion platform config for hmcts/rpx-xui-media-viewer PR #3 so the new migrated XUI media viewer repo is visible to the Jenkins/deployment-control path.

Environment approvals is intentionally not changed: that file gates prod environment deployment approval, and media-viewer does not need the old EM-style production environment approval path.

## Validation
- ruby YAML parse for deployment-controls.yml and environment-approvals.yml