### PR TITLE
SIDM-10338 whitelist private DNS CNAME record

### DIFF
--- a/terraform-infra-approvals/cnp-idam-master.json
+++ b/terraform-infra-approvals/cnp-idam-master.json
@@ -10,6 +10,7 @@
     {"type": "azurerm_linux_virtual_machine"},
     {"type": "azurerm_virtual_machine_data_disk_attachment"},
     {"type": "azurerm_private_dns_a_record"},
+    {"type": "azurerm_private_dns_cname_record"},
     {"type": "azurerm_network_interface_security_group_association"},
     {"type": "null_resource"},
     {"type": "azurerm_route_table"},


### PR DESCRIPTION
## Regular change

### JIRA link (if applicable)

SIDM-10338

### Change description

Adds repo-specific Terraform infrastructure approval for `azurerm_private_dns_cname_record` in `cnp-idam-master`.

The `cnp-idam-master` preview pipeline is currently failing before Terraform plan/apply in the `approvedTerraformInfrastructure` / `tf-utils --whitelist` gate because the DSU single-node alias uses `azurerm_private_dns_cname_record.forgerock_ds_userstore_single_node_alias`, but this resource type is not yet approved for the repo.
