### PR TITLE
Allow nightly-dev branch builds for J-to-Z nightly

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -39,7 +39,7 @@ Set<String> approvedRepos = loadApprovedRepos()
 List<Map> orgs = [
     [name: 'HMCTS_a_to_c', credentialsId: 'hmcts-jenkins-a-to-c', displayName: 'HMCTS - A to C', topic: 'jenkins-cft-a-c'],
     [name: 'HMCTS_d_to_i', credentialsId: 'hmcts-jenkins-d-to-i', displayName: 'HMCTS - D to I', topic: 'jenkins-cft-d-i'],
-    [name: 'HMCTS_j_to_z', credentialsId: 'hmcts-jenkins-j-to-z', displayName: 'HMCTS - J to Z', topic: 'jenkins-cft-j-z']
+    [name: 'HMCTS_j_to_z', credentialsId: 'hmcts-jenkins-j-to-z', displayName: 'HMCTS - J to Z', topic: 'jenkins-cft-j-z', nightlyBranchesToBuildAutomatically: ['nightly-dev']]
 ]
 
 orgs.each { Map org ->
@@ -74,6 +74,7 @@ if (isSandbox()) {
  *  - jenkinsfilePath (advanced use only): custom jenkinsfile path
  *  - suppressDefaultJenkinsfile: don't use the default Jenkinsfile
  *  - nightly: whether this is nightly org automatically set by the dsl
+ *  - nightlyBranchesToBuildAutomatically: branch names allowed to auto-build in nightly orgs
  * @param approvedRepos set of repository names approved for Jenkins inclusion via deployment-controls.yml
  */
 Closure githubOrg(Map args = [:], Set<String> approvedRepos) {
@@ -82,6 +83,7 @@ Closure githubOrg(Map args = [:], Set<String> approvedRepos) {
             jenkinsfilePath                : isSandbox() ? 'Jenkinsfile_parameterized' : 'Jenkinsfile_CNP',
             suppressDefaultJenkinsfile     : false,
             enableNamedBuildBranchStrategy : false,
+            nightlyBranchesToBuildAutomatically: [],
     ] << args
     def folderName = config.name
 
@@ -219,10 +221,19 @@ Closure githubOrg(Map args = [:], Set<String> approvedRepos) {
                     }
                 }
 
-                // prevent builds triggering automatically from SCM push for sandbox and nightly builds
+                // Prevent automatic builds for sandbox and nightly builds unless an org explicitly opts in.
                 if (enableNamedBuildBranchStrategy) {
                     node / buildStrategies / 'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl'(plugin: 'basic-branch-build-strategies@1.3.2') {
-                        filters()
+                        filters {
+                            if (config.nightly) {
+                                config.nightlyBranchesToBuildAutomatically.each { String branchName ->
+                                    'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl_-ExactNameFilter' {
+                                        name(branchName)
+                                        caseSensitive(true)
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/jobdsl/organisations-cnptest.groovy
+++ b/jobdsl/organisations-cnptest.groovy
@@ -10,7 +10,7 @@ private boolean isSandbox() {
 List<Map> orgs = [
     [name: 'HMCTS_a_to_c', credentialsId: 'hmcts-jenkins-a-to-c', displayName: 'HMCTS - A to C', topic: 'jenkins-cft-a-c'],
     [name: 'HMCTS_d_to_i', credentialsId: 'hmcts-jenkins-d-to-i', displayName: 'HMCTS - D to I', topic: 'jenkins-cft-d-i'],
-    [name: 'HMCTS_j_to_z', credentialsId: 'hmcts-jenkins-j-to-z', displayName: 'HMCTS - J to Z', topic: 'jenkins-cft-j-z']
+    [name: 'HMCTS_j_to_z', credentialsId: 'hmcts-jenkins-j-to-z', displayName: 'HMCTS - J to Z', topic: 'jenkins-cft-j-z', nightlyBranchesToBuildAutomatically: ['nightly-dev']]
 ]
 
 orgs.each { Map org ->
@@ -45,6 +45,7 @@ if (isSandbox()) {
  *  - jenkinsfilePath (advanced use only): custom jenkinsfile path
  *  - suppressDefaultJenkinsfile: don't use the default Jenkinsfile
  *  - nightly: whether this is nightly org automatically set by the dsl
+ *  - nightlyBranchesToBuildAutomatically: branch names allowed to auto-build in nightly orgs
  */
 Closure githubOrg(Map args = [:]) {
     def config = [
@@ -52,6 +53,7 @@ Closure githubOrg(Map args = [:]) {
             jenkinsfilePath                : isSandbox() ? 'Jenkinsfile_parameterized' : 'Jenkinsfile_CNP',
             suppressDefaultJenkinsfile     : false,
             enableNamedBuildBranchStrategy : false,
+            nightlyBranchesToBuildAutomatically: [],
     ] << args
     def folderName = config.name
 
@@ -170,10 +172,19 @@ Closure githubOrg(Map args = [:]) {
                     }
                 }
 
-                // prevent builds triggering automatically from SCM push for sandbox and nightly builds
+                // Prevent automatic builds for sandbox and nightly builds unless an org explicitly opts in.
                 if (enableNamedBuildBranchStrategy) {
                     node / buildStrategies / 'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl'(plugin: 'basic-branch-build-strategies@1.3.2') {
-                        filters()
+                        filters {
+                            if (config.nightly) {
+                                config.nightlyBranchesToBuildAutomatically.each { String branchName ->
+                                    'jenkins.branch.buildstrategies.basic.NamedBranchBuildStrategyImpl_-ExactNameFilter' {
+                                        name(branchName)
+                                        caseSensitive(true)
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)

---

## 🔧 Regular change

### JIRA link (if applicable)

EXUI-4915

### Change description

Allow the J-to-Z nightly organisation folder to automatically build the explicit `nightly-dev` branch.

This is needed so `hmcts/rpx-xui-media-viewer` can validate `Jenkinsfile_nightly` safely before merging the migration changes back to `master`.

The current nightly organisation config adds `NamedBranchBuildStrategyImpl` with an empty `filters` block. That disables Jenkins' default branch build behaviour and then matches no named branches, so `nightly-dev` can be indexed but cannot be automatically built.

This change:

- keeps the default nightly and sandbox suppression behaviour unchanged
- adds an explicit `nightlyBranchesToBuildAutomatically` opt-in list
- enables only `nightly-dev` for the J-to-Z nightly org
- applies the same DSL update to both `organisations-cnptest.groovy` and `organisations-beta.groovy`
- uses an exact branch-name filter rather than a wildcard

### Validation

- `git diff --check`
- `git diff --cached --check`

No repo-local Job DSL test harness was present, so validation is limited to static diff checks and the intentionally narrow generated config shape.

### Reviewer checklist

**Verify before approving:**

- [ ] Default nightly and sandbox automatic-build suppression is preserved
- [ ] Only `nightly-dev` is opted in for `HMCTS_j_to_z`
- [ ] The change does not enable broad wildcard branch builds
- [ ] `rpx-xui-media-viewer` can use the J-to-Z nightly folder to validate `nightly-dev`
