### PR TITLE
whitelisting pcs repos for prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -256,3 +256,6 @@ prod:
   - repo: https://github.com/hmcts/recipes-shared-infrastructure.git
   - repo: https://github.com/hmcts/recipes-frontend.git
   - repo: https://github.com/hmcts/recipes-backend.git
+  - repo: https://github.com/hmcts/pcs-api.git
+  - repo: https://github.com/hmcts/pcs-frontend.git
+  - repo: https://github.com/hmcts/pcs-shared-infrastructure.git


### PR DESCRIPTION
[HDPI-7460](https://tools.hmcts.net/jira/browse/HDPI-7460)

Whitelisting pcs repos 

## 🚀 New repository / enabling deployments

> Complete this section **only** when adding a repository to `deployment-controls.yml`. Remove if not applicable.

### Repository being enabled for deployment

<!-- Link to the repository e.g. https://github.com/hmcts/my-service -->

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [ ] Repository has branch protection rules enabled
- [ ] Pull requests require at least 1 approval before merging
- [ ] Status checks are required to pass before merging
- [ ] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
