### PR TITLE
Web PubSub infrastructure for rpx-case-activity-api

### DIFF
--- a/terraform-infra-approvals/rpx-case-activity-api.json
+++ b/terraform-infra-approvals/rpx-case-activity-api.json
@@ -1,0 +1,8 @@
+{
+  "resources": [
+    {"type": "azurerm_web_pubsub_network_acl"},
+    {"type": "azurerm_private_endpoint"},
+    {"type": "azurerm_role_assignment"}
+  ],
+  "module_calls": []
+}


### PR DESCRIPTION
Adds repository-specific Terraform approvals required for the rpx-case-activity-api Web PubSub private endpoint, network ACL, and non-production service-owner role assignments.

This follows the existing em-icp-api Web PubSub approval pattern.