### PR TITLE
Add completed build archive job

### DIFF
--- a/jobdsl/Jenkinsfile_seed
+++ b/jobdsl/Jenkinsfile_seed
@@ -1,11 +1,5 @@
 node {
-  checkout([$class: 'GitSCM',
-    branches: [[name: 'master']],
-    userRemoteConfigs: [[
-      url: 'https://github.com/hmcts/cnp-jenkins-config.git',
-      credentialsId: 'hmcts-jenkins-cnp'
-    ]]
-  ])
+  checkout scm
   jobDsl scriptText: readFile('jobdsl/organisations-beta.groovy'),
          removedJobAction: 'IGNORE',
          removedViewAction: 'IGNORE'

--- a/jobdsl/Jenkinsfile_seed
+++ b/jobdsl/Jenkinsfile_seed
@@ -1,5 +1,11 @@
 node {
-  checkout scm
+  checkout([$class: 'GitSCM',
+    branches: [[name: 'master']],
+    userRemoteConfigs: [[
+      url: 'https://github.com/hmcts/cnp-jenkins-config.git',
+      credentialsId: 'hmcts-jenkins-cnp'
+    ]]
+  ])
   jobDsl scriptText: readFile('jobdsl/organisations-beta.groovy'),
          removedJobAction: 'IGNORE',
          removedViewAction: 'IGNORE'

--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -50,6 +50,41 @@ orgs.each { Map org ->
     }
 }
 
+pipelineJob('Archive Completed Builds') {
+    description('Copies completed failed-build records and artifacts to long-term Azure Blob Storage.')
+
+    logRotator {
+        numToKeep(20)
+    }
+
+    parameters {
+        stringParam('SOURCE_BUILD_URL', '', 'URL of the completed Jenkins build to archive.')
+        stringParam('SOURCE_JOB_NAME', '', 'Full Jenkins name of the source job.')
+        stringParam('SOURCE_BUILD_NUMBER', '', 'Jenkins build number to archive.')
+        stringParam('SOURCE_BUILD_RESULT', '', 'Final result of the source build.')
+        stringParam('SOURCE_PRODUCT', '', 'Product identifier supplied by the source pipeline.')
+        stringParam('SOURCE_COMPONENT', '', 'Component identifier supplied by the source pipeline.')
+    }
+
+    definition {
+        cps {
+            script('''
+                @Library('Infrastructure@archive-complete-build-results') _
+
+                archiveCompletedBuild(
+                    sourceBuildUrl: params.SOURCE_BUILD_URL,
+                    sourceJobName: params.SOURCE_JOB_NAME,
+                    sourceBuildNumber: params.SOURCE_BUILD_NUMBER,
+                    sourceBuildResult: params.SOURCE_BUILD_RESULT,
+                    sourceProduct: params.SOURCE_PRODUCT,
+                    sourceComponent: params.SOURCE_COMPONENT
+                )
+            '''.stripIndent())
+            sandbox()
+        }
+    }
+}
+
 if (isSandbox()) {
     Map pipelineTestOrg = [
             name                           : 'Pipeline_Test',

--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -69,7 +69,7 @@ pipelineJob('Archive Completed Builds') {
     definition {
         cps {
             script('''
-                @Library('Infrastructure@archive-complete-build-results') _
+                @Library('Infrastructure@master') _
 
                 archiveCompletedBuild(
                     sourceBuildUrl: params.SOURCE_BUILD_URL,


### PR DESCRIPTION
## What changed

- Add the root-level `Archive Completed Builds` pipeline job through the existing Job DSL seed.
- Define the six source-build parameters supplied by `queueBuildArchive`.
- Run `archiveCompletedBuild` from the `archive-complete-build-results` library branch.
- Retain the latest 20 archive-worker runs in Jenkins.

## Why

The failed downstream test in [et-ccd-callbacks#3347](https://github.com/hmcts/et-ccd-callbacks/pull/3347) reached the archive trigger but reported:

```text
Unable to queue build archive: No item named /Archive Completed Builds found
```

The shared-library implementation requires a separate Jenkins job so it can wait for the source build to finish before retrieving its completed console, metadata, test results and artifacts.

## Impact

This provisions the worker expected by [cnp-jenkins-library#1495](https://github.com/hmcts/cnp-jenkins-library/pull/1495).
[cnp-jenkins-library#1497](https://github.com/hmcts/cnp-jenkins-library/pull/1497) removes the proposed Jenkins API credential by reading source builds directly from the controller. The worker continues to use the existing `buildlog-storage-account` credential and `jenkins-build-archive` container.

Application pipelines only queue the worker after a final `FAILURE` result.

## Validation

- `git diff --check`
- Confirmed the job name and parameter contract match `queueBuildArchive.groovy` and `archiveCompletedBuild.groovy` on the feature branch.

## Dependencies

- [cnp-jenkins-library#1495](https://github.com/hmcts/cnp-jenkins-library/pull/1495)
- [cnp-jenkins-library#1497](https://github.com/hmcts/cnp-jenkins-library/pull/1497)

Keep this PR as draft until the root job and credential-free library path have passed the downstream trial.
