### PR TITLE
feat(AMP-944): add service-api-marketplace Jenkins config

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -635,6 +635,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/service-auth-provider-java-client.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/service-api-marketplace.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/Special-Tribunals-Perftest.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/sptribs-case-api.git

--- a/terraform-infra-approvals/cnp-apimarketplace-service.json
+++ b/terraform-infra-approvals/cnp-apimarketplace-service.json
@@ -1,6 +1,0 @@
-{
-    "resources": [
-        {"type": "azurerm_key_vault_access_policy"}
-    ],
-    "module_calls": []
-}

--- a/terraform-infra-approvals/service-api-marketplace.json
+++ b/terraform-infra-approvals/service-api-marketplace.json
@@ -1,0 +1,8 @@
+{
+  "resources": [
+    {"type": "azurerm_key_vault_access_policy"}
+  ],
+  "module_calls": [
+    {"source": "git@github.com:hmcts/cnp-module-key-vault"}
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `terraform-infra-approvals/service-api-marketplace.json` — permits `cnp-module-key-vault` module and `azurerm_key_vault_access_policy` resource type for Terraform runs
- Add `service-api-marketplace` to `deployment-controls.yml` to enable Docker push and AKS deployment in Jenkins
- Remove `terraform-infra-approvals/cnp-apimarketplace-service.json` — dead config for the abandoned `cnp-apimarketplace-service` repo

## Notes

This PR must be merged before the first Jenkins build of `hmcts/service-api-marketplace` — Jenkins fetches the TF approval whitelist at runtime and returns a hard 404 failure if it is missing.