### PR TITLE
Add et-ccd-callbacks.json for database resource configurations

### DIFF
--- a/terraform-infra-approvals/et-ccd-callbacks.json
+++ b/terraform-infra-approvals/et-ccd-callbacks.json
@@ -1,0 +1,8 @@
+{
+  "resources": [
+    {"type": "random_password"},
+    {"type": "postgresql_role"},
+    {"type": "postgresql_grant"},
+    {"type": "postgresql_default_privileges"}
+  ]
+}


### PR DESCRIPTION
Add et-ccd-callbacks.json for database resource configurations so ET team can create a read only user for SDP Ingestion - https://github.com/hmcts/et-ccd-callbacks/pull/3389