### PR TITLE
EXUI-5084: register rpx-xui-icp-api with Jenkins

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 deployment-controls.yml @hmcts/platform-operations
 environment-approvals.yml @hmcts/production-apps-approvals
-terraform-infra-approvals.yml/*.json @hmcts/production-apps-approvals
+terraform-infra-approvals/*.json @hmcts/production-apps-approvals

--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -621,6 +621,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-e2e-tests.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/rpx-xui-icp-api.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-manage-organisations.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-media-viewer.git

--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -158,6 +158,7 @@ prod:
   - repo: https://github.com/hmcts/rpe-shared-infrastructure.git
   - repo: https://github.com/hmcts/rpx-shared-infrastructure.git
   - repo: https://github.com/hmcts/rpx-xui-approve-org.git
+  - repo: https://github.com/hmcts/rpx-xui-icp-api.git
   - repo: https://github.com/hmcts/rpx-xui-manage-organisations.git
   - repo: https://github.com/hmcts/rpx-xui-webapp.git
   - repo: https://github.com/hmcts/rpx-xui-terms-and-conditions.git

--- a/terraform-infra-approvals/rpx-xui-icp-api.json
+++ b/terraform-infra-approvals/rpx-xui-icp-api.json
@@ -1,0 +1,8 @@
+{
+    "resources": [
+      {"type": "azurerm_web_pubsub_network_acl"},
+      {"type": "azurerm_private_endpoint"},
+      {"type": "azurerm_role_assignment"}
+    ],
+    "module_calls": []
+}


### PR DESCRIPTION
## 🔧 Regular change

### JIRA link 

[EXUI-5084](https://tools.hmcts.net/jira/browse/EXUI-5084)

### Change description

Register `rpx-xui-icp-api` for Jenkins deployments and production approvals, and preserve the existing ICP Terraform resource approval contract under the new repository short name.

The existing `em-icp-api` entries remain during cutover so rollback remains possible until the service, consumers and deployment automation have been proven against the XUI repository.

Validation completed:

- both YAML files parse successfully
- the new JSON file parses successfully
- the repository occurs exactly once in deployment controls and production approvals
- deployment is enabled
- the Terraform approval file is byte-identical to `em-icp-api.json`
- `git diff --check`

AI assistance was used to compare migration controls and prepare this change. Human review is required before merge.

---

## 🚀 New repository / enabling deployments

### Repository being enabled for deployment

https://github.com/hmcts/rpx-xui-icp-api

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [x] Repository has branch protection rules enabled
- [x] Pull requests require at least 1 approval before merging (configured for 2)
- [x] Status checks are required to pass before merging (`build`)
- [ ] Repository has a `SECURITY.md` file — [rpx-xui-icp-api PR #14](https://github.com/hmcts/rpx-xui-icp-api/pull/14) must be merged before this PR is approved
