### PR TITLE
Update included branches on sanbdox to improve scanning speed

### DIFF
--- a/jobdsl/organisations-beta.groovy
+++ b/jobdsl/organisations-beta.groovy
@@ -136,7 +136,7 @@ Closure githubOrg(Map args = [:], Set<String> approvedRepos) {
 
     if (runningOnSandbox) {
         folderSuffix = '_Sandbox'
-        wildcardBranchesToInclude = '*'
+        wildcardBranchesToInclude = 'master PR-*'
         // We want the labs folder to build on push but others don't need to
         enableNamedBuildBranchStrategy = config.name == 'LABS' || config.name == 'Pipeline_Test' ? false : true
     }


### PR DESCRIPTION
## 🔧 Regular change

### Change description

Scanning orgs on CFT sandbox are taking two hours which is unnecessary
Removing wildcard and adding master and `PR-` instead
