### PR TITLE
EXUI-5084: hold ICP API Jenkins activation

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -623,8 +623,6 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-e2e-tests.git
     deployment-enabled: true
-  - repo: https://github.com/hmcts/rpx-xui-icp-api.git
-    deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-manage-organisations.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/rpx-xui-media-viewer.git

--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -158,7 +158,6 @@ prod:
   - repo: https://github.com/hmcts/rpe-shared-infrastructure.git
   - repo: https://github.com/hmcts/rpx-shared-infrastructure.git
   - repo: https://github.com/hmcts/rpx-xui-approve-org.git
-  - repo: https://github.com/hmcts/rpx-xui-icp-api.git
   - repo: https://github.com/hmcts/rpx-xui-manage-organisations.git
   - repo: https://github.com/hmcts/rpx-xui-webapp.git
   - repo: https://github.com/hmcts/rpx-xui-terms-and-conditions.git

--- a/terraform-infra-approvals/rpx-xui-icp-api.json
+++ b/terraform-infra-approvals/rpx-xui-icp-api.json
@@ -1,8 +1,0 @@
-{
-    "resources": [
-      {"type": "azurerm_web_pubsub_network_acl"},
-      {"type": "azurerm_private_endpoint"},
-      {"type": "azurerm_role_assignment"}
-    ],
-    "module_calls": []
-}


### PR DESCRIPTION
## Regular change

### JIRA link

https://tools.hmcts.net/jira/browse/EXUI-5084

### Change description

Temporarily removes `rpx-xui-icp-api` from Jenkins discovery and deployment approvals while the destination pipeline contract is corrected.

This is a reversible safety hold. The destination currently has no normal or nightly Jenkins job and its `jenkins-cft-j-z` topic has also been removed. The existing `em-icp-api` Jenkins route and runtime are unchanged.

The PR removes only:

- the destination entry from `deployment-controls.yml`;
- the destination entry from the production section of `environment-approvals.yml`;
- `terraform-infra-approvals/rpx-xui-icp-api.json`.

The CODEOWNERS correction from PR 1304 is deliberately retained. Registrations will be restored through a separate reviewed PR only after destination `master` is safe to execute automatically.

Validation:

- `git diff --check`
- YAML safe-load of both changed YAML files
- `jq` parse of all remaining Terraform approval JSON files
