### PR TITLE
Approve opal-shared-infrastructure for prod

### DIFF
--- a/environment-approvals.yml
+++ b/environment-approvals.yml
@@ -122,6 +122,7 @@ prod:
   - repo: https://github.com/hmcts/nfdiv-case-api.git
   - repo: https://github.com/hmcts/nfdiv-frontend.git
   - repo: https://github.com/hmcts/nfdiv-shared-infrastructure.git
+  - repo: https://github.com/hmcts/opal-shared-infrastructure.git
   - repo: https://github.com/hmcts/pcq-shared-infrastructure.git
   - repo: https://github.com/hmcts/pcq-consolidation-service.git
   - repo: https://github.com/hmcts/pcq-frontend.git


### PR DESCRIPTION
## 🔧 Regular change

### Change description

Add `opal-shared-infrastructure` to the production environment approval list so its master infrastructure pipeline can run the prod Terraform stage after STG succeeds.

This PR only enables the prod pipeline stage; it does not change Terraform resources or recreate any containers.

### Validation

- Parsed `environment-approvals.yml` successfully with `yq`
- Confirmed the repository appears exactly once in the prod approval list
- Ran `git diff --check`
