### PR TITLE
AMP-1031: enable deployment for web-api-marketplace

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -357,8 +357,6 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/fpl-wa-task-configuration.git
     deployment-enabled: true
-  - repo: https://github.com/hmcts/frontend-api-marketplace.git
-    deployment-enabled: true
   - repo: https://github.com/hmcts/halo-itsm-bpt.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/help-with-fees-shared-infrastructure.git
@@ -712,6 +710,8 @@ repositories:
   - repo: https://github.com/hmcts/wa-task-monitor.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/wa-workflow-api.git
+    deployment-enabled: true
+  - repo: https://github.com/hmcts/web-api-marketplace.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/xui-performance.git
     deployment-enabled: true

--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -357,6 +357,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/fpl-wa-task-configuration.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/frontend-api-marketplace.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/halo-itsm-bpt.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/help-with-fees-shared-infrastructure.git


### PR DESCRIPTION
Enables the Jenkins pipeline for the new API Marketplace web frontend.

`hmcts/web-api-marketplace` is a Node.js GOV.UK frontend for the `apim` product
(component `marketplace-web`), alongside the existing `service-api-marketplace`
backend. Without this entry the pipeline is limited to checkout, build and static QA
— no Docker publish, no AKS deployment.

- Repo: https://github.com/hmcts/web-api-marketplace
- Product / component: `apim` / `marketplace-web`
- Topic `jenkins-cft-j-z`, so it lands in `HMCTS_j_to_z` with the backend
- Helm chart `apim-marketplace-web`, image `hmctsprod.azurecr.io/apim/marketplace-web`

No `terraform-infra-approvals` file is needed — the repo has no `infrastructure/`
directory, so the pipeline runs no Terraform stage.

Flux configuration: hmcts/cnp-flux-config#47001

Ticket: AMP-1031
