### PR TITLE
Allow AI services module and cognitive account for sptribs-shared-infrastructure

### DIFF
--- a/terraform-infra-approvals/sptribs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sptribs-shared-infrastructure.json
@@ -7,6 +7,6 @@
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-27514"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=custom-schema-support"},
-    {"source":  "github.com/hmcts/terraform-module-ai-services?ref=main"}
+    {"source":  "git@github.com:hmcts/terraform-module-ai-services?ref=main"}
   ]
 }

--- a/terraform-infra-approvals/sptribs-shared-infrastructure.json
+++ b/terraform-infra-approvals/sptribs-shared-infrastructure.json
@@ -1,9 +1,12 @@
 {
   "resources": [
-    {"type": "azurerm_servicebus_topic_authorization_rule"}
+    {"type": "azurerm_servicebus_topic_authorization_rule"},
+    {"type": "azurerm_cognitive_account"},
+    {"type": "azurerm_role_assignment"}
   ],
   "module_calls": [
     {"source":  "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-27514"},
-    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=custom-schema-support"}
+    {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=custom-schema-support"},
+    {"source":  "github.com/hmcts/terraform-module-ai-services?ref=main"}
   ]
 }


### PR DESCRIPTION
Unblocks hmcts/sptribs-shared-infrastructure#67, which adds an Azure Document Intelligence (`FormRecognizer`) account so sptribs can OCR CIC case documents before sending the extracted text to the AI Gateway for interpretation.

### What's added to `sptribs-shared-infrastructure.json`

| Entry | Why |
| --- | --- |
| `azurerm_cognitive_account` | The Document Intelligence account itself, created by the module |
| `azurerm_role_assignment` | Data-plane grant (`Cognitive Services User`) letting `sptribs-case-api` call the analyze API as its own workload identity |
| `github.com/hmcts/terraform-module-ai-services?ref=main` | The module call |

The module source string matches the consuming Terraform exactly, in the `git@github.com:…` SSH form used by the other entries in this file and by sptribs' other module calls.

`azurerm_role_assignment` is already approved for `cnp-plum-shared-infrastructure`; `azurerm_cognitive_account` is **not currently approved for any repo in this list**, so sptribs would be the first CFT product with it.

### Worth a platform view

Given that's a first, it's reasonable to ask whether team-owned Document Intelligence accounts are the intended pattern, or whether OCR should become a shared AI Gateway capability. Flagged the same question on the consuming PR — happy for this to wait on that answer.

JSON validated.
