### PR TITLE
Freeze pcs-api and pcs-frontend deployments during model office testing on AAT

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -500,9 +500,11 @@ repositories:
   - repo: https://github.com/hmcts/pcq-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/pcs-api.git
-    deployment-enabled: true
+    # Temporary freeze: model office testing on AAT, no new deployments until testing completes (PCS team, 26 Aug)
+    deployment-enabled: false
   - repo: https://github.com/hmcts/pcs-frontend.git
-    deployment-enabled: true
+    # Temporary freeze: model office testing on AAT, no new deployments until testing completes (PCS team, 26 Aug)
+    deployment-enabled: false
   - repo: https://github.com/hmcts/pcs-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/performance-test-orchestrator.git


### PR DESCRIPTION
### Change description

Sets deployment-enabled: false for pcs-api and pcs-frontend, with a comment marking it as a temporary freeze.

Model office testing is running on the PCS AAT environment and no new code must reach it while that is in progress. Code is already merged to pcs-api master that has not yet deployed (recent builds failed on an environment issue), and the repo's renovate config automerges on a schedule (next window 17:00 today), so a green build this afternoon would deploy and slot-swap onto AAT mid-testing.

deployment-enabled: false blocks the deploy stages while letting PRs and master builds run, which is the freeze shape we need. A revert PR will follow as soon as model office testing completes (expected within a day or two); the PCS team will raise it.

Requested urgently: the next renovate automerge window opens at 17:00 today, so a merge before then closes the exposure.