### PR TITLE
Re-enable pcs-api and pcs-frontend deployments after model office testing

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -500,11 +500,9 @@ repositories:
   - repo: https://github.com/hmcts/pcq-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/pcs-api.git
-    # Temporary freeze: model office testing on AAT, no new deployments until testing completes (PCS team, 26 Aug)
-    deployment-enabled: false
+    deployment-enabled: true
   - repo: https://github.com/hmcts/pcs-frontend.git
-    # Temporary freeze: model office testing on AAT, no new deployments until testing completes (PCS team, 26 Aug)
-    deployment-enabled: false
+    deployment-enabled: true
   - repo: https://github.com/hmcts/pcs-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/performance-test-orchestrator.git


### PR DESCRIPTION
### Change description

Reverts the temporary freeze from #1324: deployment-enabled back to true for pcs-api and pcs-frontend, freeze comments removed.

Model office testing on the PCS AAT environment completes at 17:00 today; this restores normal deployments from then. Please merge by 17:00 so the team can resume merging and deploying this evening.