### PR TITLE
Fixing broken plum infra builds

### DIFF
--- a/terraform-infra-approvals/cnp-plum-shared-infrastructure.json
+++ b/terraform-infra-approvals/cnp-plum-shared-infrastructure.json
@@ -7,6 +7,7 @@
     {"source": "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-16829-prepare"},
     {"source": "git@github.com:hmcts/terraform-module-application-insights?ref=DTSPO-28826-Reduce-log-analytics-cost-in-nonprod"},
     {"source": "git@github.com:hmcts/cnp-module-webapp?ref=DTSPO-30615-modernise-module"},
-    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=feat/allow-rbac-auth"}
+    {"source": "git@github.com:hmcts/cnp-module-key-vault?ref=feat/allow-rbac-auth"},
+    {"source": "git@github.com/hmcts/terraform-module-ai-services?ref=main"}
   ]
 }


### PR DESCRIPTION
Error was:
...repo is using a terraform resource that is not allowed,
on whitelisted resources:
...github.com/hmcts/terraform-module-ai-services?ref=main 

Master build is currently broken https://github.com/hmcts/cnp-plum-shared-infrastructure/blob/94c66856a23c6c5c54d79324b3d1b763597b912a/ai-services.tf#L9

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)

Please remove this line and everything above and complete the relevant section(s) below.

---

## 🔧 Regular change

> Complete this section for configuration changes, fixes, and general updates. Remove if not applicable.

### JIRA link (if applicable)

### Change description

---

## 🚀 New repository / enabling deployments

> Complete this section **only** when adding a repository to `deployment-controls.yml`. Remove if not applicable.

### Repository being enabled for deployment

<!-- Link to the repository e.g. https://github.com/hmcts/my-service -->

### Reviewer checklist

**Verify the repository meets all of the following before approving:**

- [ ] Repository has branch protection rules enabled
- [ ] Pull requests require at least 1 approval before merging
- [ ] Status checks are required to pass before merging
- [ ] Repository has a `SECURITY.md` file (documents vulnerability reporting, more details [here](https://hmcts.github.io/standards/practices/Public-Repositories.html#vulnerability-reporting), template is [here](https://github.com/hmcts/hmcts.github.io/blob/main/security.md))
