### PR TITLE
Add dtsse-github-metrics to deployment controls

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -236,6 +236,7 @@ repositories:
   - repo: https://github.com/hmcts/dtsse-dashboard-ingestion.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/dtsse-github-metrics.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/dtsse-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/ecm-ccd-case-migration.git

--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -237,8 +237,6 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/dtsse-github-metrics.git
     deployment-enabled: true
-  - repo: https://github.com/hmcts/dtsse-shared-infrastructure.git
-    deployment-enabled: true
   - repo: https://github.com/hmcts/ecm-ccd-case-migration.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/ecm-consumer.git

--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -235,6 +235,9 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/dtsse-dashboard-ingestion.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/dtsse-github-metrics.git
+  - repo: https://github.com/hmcts/dtsse-shared-infrastructure.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/ecm-ccd-case-migration.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/ecm-consumer.git


### PR DESCRIPTION
Adds `dtsse-github-metrics`, the Node.js rewrite of [`hmcts/github-metrics`](https://github.com/hmcts/github-metrics).

The repository carries the `jenkins-cft-d-i` topic so the org scan finds it, but nothing deploys without an entry here — `DeploymentControls.isDeployEnabled` requires `deployment-enabled == true`.

Enabled so previews build and deploy: the repository's Playwright smoke suite runs against the preview environment, so without it the pipeline could not go green. Production promotion is governed separately by `environment-approvals.yml`, which it is not yet in.

## Checks

- `yq` parses the file; 374 entries
- Entry is alphabetical, in the existing two-line format