### PR TITLE
Allow random_password for service-api-marketplace

### DIFF
--- a/terraform-infra-approvals/service-api-marketplace.json
+++ b/terraform-infra-approvals/service-api-marketplace.json
@@ -1,7 +1,8 @@
 {
   "resources": [
     {"type": "azurerm_key_vault_access_policy"},
-    {"type": "azurerm_key_vault_secret"}
+    {"type": "azurerm_key_vault_secret"},
+    {"type": "random_password"}
   ],
   "module_calls": [
     {"source": "git@github.com:hmcts/cnp-module-key-vault"},


### PR DESCRIPTION
One line added to `terraform-infra-approvals/service-api-marketplace.json`:

```diff
     {"type": "azurerm_key_vault_secret"},
+    {"type": "random_password"}
```

## Why

`service-api-marketplace` hashes user passwords with bcrypt plus a server-side pepper held in the product key vault. Unlike the postgres secrets, the pepper has no source resource to derive it from, so terraform generates it with `random_password` and writes it using the already-approved `azurerm_key_vault_secret`.

Without it the infrastructure stage rejects the config before terraform runs, so the repo currently cannot deploy to AAT at all.

## Why not create it by hand instead

The vault's access policies grant individual developers `Get` and `List` only — `Set` goes to Jenkins and the team group. So the owning developers cannot create it themselves, and a per-environment manual step would need someone else every time a new environment is stood up.

## Precedent

`random_password` is already whitelisted for `cui-ra`, `ia-case-api` and `pcq-frontend` among others, so this follows existing practice rather than setting a new one.

## Blast radius

Scoped to this one repo's approvals file. No change to `global.json` or any other service.