### PR TITLE
Allow ai services module globally

### DIFF
--- a/terraform-infra-approvals/global.json
+++ b/terraform-infra-approvals/global.json
@@ -77,6 +77,7 @@
     {"source":  "git@github.com:hmcts/terraform-module-azure-managed-redis?ref=main"},
     {"source":  "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=CME-120"},
     {"source":  "git@github.com:hmcts/terraform-module-vm-bootstrap?ref=master"},
-    {"source":  "git::https://github.com/hmcts/cnp-module-metric-alert.git"}
+    {"source":  "git::https://github.com/hmcts/cnp-module-metric-alert.git"},
+    {"source":  "git@github.com/hmcts/terraform-module-ai-services?ref=main"}
   ]
 }


### PR DESCRIPTION
## Jira link

https://tools.hmcts.net/jira/browse/DTSPO-34621

## 🔧 Regular change

Module is not currently allowed
It is being used in cnp-plum-infrastructure
Don't see any reason to limit it just to that repo as others are being tested
Currently blocking being able to test other features like jenkins library branches
