### PR TITLE
Add hmcts-api-marketplace-auth to the deployment allowlist

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -375,6 +375,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/hmc-shared-infrastructure.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/hmcts-api-marketplace-auth.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/hofse-ardoq-api-prototype.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/hwf-benefit-checker-api.git


### PR DESCRIPTION
Onboarding hmcts-api-marketplace-auth (moving off Render onto AKS/CNP). Adds it to deployment-controls.yml so the Jenkins org scan picks it up, per https://hmcts.github.io/cloud-native-platform/new-component/jenkins-repository.html.

Repo falls in the D-I alphabetical group (`jenkins-cft-d-i` topic) - adding that topic to the repo in parallel.