### PR TITLE
Allow deployments for sptribs-send-prototype

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -653,6 +653,8 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/sptribs-frontend.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/sptribs-send-prototype.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/sptribs-shared-infrastructure.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/sscs-case-loader.git


### PR DESCRIPTION
Adds `hmcts/sptribs-send-prototype` to the deployment allowlist.

It is a prototype citizen frontend for the SEND35 appeal journey — *appeal a decision about an
education, health and care (EHC) plan* — for the First-tier Tribunal (Special Educational Needs
and Disability). It pairs with a `StSend35` CCD case type in
[sptribs-case-api#2642](https://github.com/hmcts/sptribs-case-api/pull/2642).

Without this entry Jenkins does not pick the repo up in the org scan, so no image is published
and nothing reaches Preview.

- Repo: <https://github.com/hmcts/sptribs-send-prototype> (public)
- Topic: `jenkins-cft-j-z`
- Product `sptribs` is already in `team-config.yml`, so the namespace, AAD group and Slack
  channels are in place.

Preview only. Master carries no `Jenkinsfile_CNP`, so nothing deploys to AAT and the repo is not
in `environment-approvals.yml`.
