### PR TITLE
Onboard the four deed-poll repositories: team config and deployment allowlist

### DIFF
--- a/deployment-controls.yml
+++ b/deployment-controls.yml
@@ -189,6 +189,14 @@ repositories:
     deployment-enabled: true
   - repo: https://github.com/hmcts/data-ingestion-lib.git
     deployment-enabled: true
+  - repo: https://github.com/hmcts/deed-poll-admin.git
+    deployment-enabled: true
+  - repo: https://github.com/hmcts/deed-poll-api.git
+    deployment-enabled: true
+  - repo: https://github.com/hmcts/deed-poll-infra.git
+    deployment-enabled: true
+  - repo: https://github.com/hmcts/deed-poll-web.git
+    deployment-enabled: true
   - repo: https://github.com/hmcts/devextreme-poc-spa.git
     deployment-enabled: true
   - repo: https://github.com/hmcts/devextreme-poc-ssr.git

--- a/team-config.yml
+++ b/team-config.yml
@@ -1035,3 +1035,13 @@ performance:
     build_notices_channel: "#performance-build-notices"
   tags:
     application: performance
+deed-poll:
+  team: "Deed Poll"
+  namespace: "deed-poll"
+  azure_ad_group: DTS Deed Poll
+  slack:
+    contact_channel: "#adoption-tech"
+    channel_id: "C02KDUDL9LG"
+    build_notices_channel: "#adoption-tech"
+  tags:
+    application: deed-poll


### PR DESCRIPTION
## 🔧 Regular change

### JIRA link (if applicable)

None. This is a new CFT product — "Change your name by deed poll" — commissioned outside the usual Digital Delivery route, so there is no delivery-board ticket to reference. Contact @NewmanJustice for background.

### Change description

Two files, one product:

**`team-config.yml`** — adds a `deed-poll` product entry. This is the load-bearing half: `TeamConfig.setTeamConfigEnv` errors outright on a missing `namespace`, `slack.contact_channel`, `slack.build_notices_channel` or `tags.application`, so without it none of the four repositories can build at all.

One entry covers all three applications: `deed-poll-admin`, `deed-poll-api` and `deed-poll-web` all declare `product = "deed-poll"` and differ only by component, as `pcs` does.

`azure_ad_group: DTS Deed Poll` matches the group [`deed-poll-infra`](https://github.com/hmcts/deed-poll-infra) already passes to `cnp-module-key-vault` as `product_group_name`. The Slack channels point at `#adoption-tech`, the existing channel of the team that owns this work.

**`deployment-controls.yml`** — adds the four repositories with `deployment-enabled: true`, in alphabetical position. `deed-poll-infra` is included despite owning no application, following the precedent of the `*-shared-infrastructure` repositories already listed.

---

## 🚀 New repository / enabling deployments

### Repository being enabled for deployment

| Repository | Pipeline | Chart |
|---|---|---|
| [`deed-poll-admin`](https://github.com/hmcts/deed-poll-admin) | `Jenkinsfile_CNP` — `nodejs` / `deed-poll` / `admin` | `helm/deed-poll-admin` |
| [`deed-poll-api`](https://github.com/hmcts/deed-poll-api) | `Jenkinsfile_CNP` — `java` / `deed-poll` / `api` | `charts/deed-poll-api` |
| [`deed-poll-web`](https://github.com/hmcts/deed-poll-web) | `Jenkinsfile_CNP` — `nodejs` / `deed-poll` / `web` | `charts/deed-poll-web` |
| [`deed-poll-infra`](https://github.com/hmcts/deed-poll-infra) | Terraform only — resource group, Key Vault, Postgres, Redis, App Insights | n/a |

All four declare `@Library("Infrastructure@2.4.4") _`. The shared `deed-poll-{env}` Key Vault that all three applications read is created by `deed-poll-infra` and has not been applied yet, so `deed-poll-infra` needs to build first.

The GitHub topic `jenkins-cft-d-i` is being added to all four alongside this PR.

### Reviewer checklist

Stated honestly rather than pre-ticked — two items are outstanding on our side and we are not asking you to take them on trust:

- [ ] Repository has branch protection rules enabled — **not yet.** None of the four has a ruleset or classic branch protection today. We are configuring rulesets on the default branch, modelled on `pcs-api`'s, and will confirm here before asking for merge.
- [ ] Pull requests require at least 1 approval before merging — **covered by the same ruleset work above.**
- [ ] Status checks are required to pass before merging — **covered by the same ruleset work above**, requiring `continuous-integration/jenkins/pr-head`. Worth noting this check cannot exist until this PR merges and the org scan runs, so there is a small ordering knot here — happy to take guidance on which way you prefer to resolve it.
- [x] Repository has a `SECURITY.md` file — `deed-poll-admin`, `deed-poll-api` and `deed-poll-web` already have one; `deed-poll-infra` was the gap and is fixed in hmcts/deed-poll-infra#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)